### PR TITLE
Add \Device\KsecDD emulation and mask 32-bit syscall arguments

### DIFF
--- a/Brovan/Brovan.csproj
+++ b/Brovan/Brovan.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -33,8 +33,13 @@
 		<Copy SourceFiles="$(ProjectDir)Resources\libunicorn.so" DestinationFolder="$(PublishDir)" Condition="'$(RuntimeIdentifier)' != '' And $([System.String]::Copy('$(RuntimeIdentifier)').Contains('linux'))" SkipUnchangedFiles="true" />
 	</Target>
 
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-		<Exec Command="@echo off&#xA;:: Detect if this is a Linux target build&#xA;set &quot;RID=$(RuntimeIdentifier)&quot;&#xA;set &quot;IS_LINUX=0&quot;&#xA;if not &quot;%25RID%25&quot;==&quot;&quot; (&#xA;  echo %25RID%25 | findstr /i &quot;linux&quot; &gt;nul 2&gt;&amp;1&#xA;  if not errorlevel 1 set &quot;IS_LINUX=1&quot;&#xA;)&#xA;&#xA;:: Copy the appropriate unicorn library to the target directory&#xA;if &quot;%25IS_LINUX%25&quot;==&quot;1&quot; (&#xA;  copy /Y &quot;$(ProjectDir)Resources\libunicorn.so&quot; &quot;$(TargetDir)&quot; &gt;nul 2&gt;&amp;1&#xA;  if errorlevel 1 (&#xA;    echo Warning: Failed to copy libunicorn.so to the target path.&#xA;  ) else (&#xA;    echo Copied libunicorn.so to the target path successfully.&#xA;  )&#xA;) else (&#xA;  copy /Y &quot;$(ProjectDir)Resources\unicorn.dll&quot; &quot;$(TargetDir)&quot; &gt;nul 2&gt;&amp;1&#xA;  if errorlevel 1 (&#xA;    echo Warning: Failed to copy unicorn.dll to the target path.&#xA;  ) else (&#xA;    echo Copied unicorn.dll to the target path successfully.&#xA;  )&#xA;)&#xA;&#xA;:: Skip editbin entirely for Linux builds&#xA;if &quot;%25IS_LINUX%25&quot;==&quot;1&quot; (&#xA;  echo Skipping editbin for Linux build.&#xA;  exit /b 0&#xA;)&#xA;&#xA;:: Get the target path (which is the dll)&#xA;set &quot;ORIGINAL_PATH=$(TargetPath)&quot;&#xA;:: Replace the target path dll extension with an exe extension to pass it to editbin later.&#xA;set &quot;MODIFIED_PATH=%25ORIGINAL_PATH:.dll=.exe%25&quot;&#xA;echo Calling VsDevCmd.bat...&#xA;call &quot;$(DevEnvDir)..\Tools\VsDevCmd.bat&quot; &gt;nul 2&gt;&amp;1&#xA;if errorlevel 1 (&#xA;  echo Warning: Couldn't execute visual studio developer command prompt.&#xA;  exit /b 0&#xA;)&#xA;:: Check if editbin.exe is now available&#xA;where editbin.exe &gt;nul 2&gt;&amp;1&#xA;if errorlevel 1 (&#xA;  echo Warning: editbin.exe not found in environment. CFG won't be disabled, Brovan will try to disable it at runtime.&#xA;) else (&#xA;  :: Disable CFG using editbin.exe&#xA;  editbin.exe /GUARD:NO %25MODIFIED_PATH%25 &gt;nul 2&gt;&amp;1&#xA;  if errorlevel 1 (&#xA;    echo editbin.exe failed to run, CFG won't be disabled so Brovan will try to disable it at runtime.&#xA;  ) else (&#xA;    echo Disabled CFG using editbin.exe successfully.&#xA;  )&#xA;)&#xA;exit /b 0" />
+	<PropertyGroup>
+		<_ModifiedTargetPath>$([System.String]::Copy('$(TargetPath)').Replace('.dll', '.exe'))</_ModifiedTargetPath>
+	</PropertyGroup>
+
+	<Target Name="PostBuild" AfterTargets="Build" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+		<Message Text="Skipping editbin for Linux build." Importance="high" Condition="'$(RuntimeIdentifier)' != '' And $([System.String]::Copy('$(RuntimeIdentifier)').Contains('linux'))" />
+		<Exec Command="call &quot;$(DevEnvDir)..\Tools\VsDevCmd.bat&quot; &gt;nul 2&gt;&amp;1 &amp;&amp; where editbin.exe &gt;nul 2&gt;&amp;1 &amp;&amp; editbin.exe /GUARD:NO &quot;$(_ModifiedTargetPath)&quot; &gt;nul 2&gt;&amp;1" Condition="'$(RuntimeIdentifier)' == '' Or $([System.String]::Copy('$(RuntimeIdentifier)').Contains('linux')) == false" IgnoreExitCode="true" />
 	</Target>
 
   <ItemGroup>

--- a/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Brovan.Core.Emulation.OS.Windows
+{
+    /// <summary>
+    /// Emulates <c>\Device\KsecDD</c> (Kernel Security Support Provider device). During process
+    /// initialization bcrypt/CNG (and the CRT) open this device and use it for random number
+    /// generation (IOCTL_KSEC_RNG) and for RtlEncryptMemory/RtlDecryptMemory
+    /// (IOCTL_KSEC_*_MEMORY). If the open fails the owning DllMain returns FALSE and the process
+    /// aborts with STATUS_DLL_INIT_FAILED, so the device must at least be openable.
+    /// </summary>
+    internal sealed class KsecDevice : IWinDevice
+    {
+        public string DeviceName => "\\Device\\KsecDD";
+
+        private const uint IOCTL_KSEC_RNG = 0x390004;
+        private const uint IOCTL_KSEC_RNG_REKEY = 0x390008;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY = 0x39000C;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY = 0x390010;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_CROSS_PROCESS = 0x390014;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY_CROSS_PROCESS = 0x390018;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON = 0x39001C;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON = 0x390020;
+        // FILE_DEVICE_KSEC function 0x100 (104-byte input, 8-byte output). bcrypt/CNG issues this
+        // from its DllMain during process init and only requires the call to succeed.
+        private const uint IOCTL_KSEC_CLIENT_HANDSHAKE = 0x390400;
+
+        public NTSTATUS Create(BinaryEmulator Instance, string DevicePath, byte[] EaBuffer, out string InternalPath, out WinDeviceDelegate Handler)
+        {
+            InternalPath = DevicePath;
+            Handler = Handle;
+            return NTSTATUS.STATUS_SUCCESS;
+        }
+
+        private NTSTATUS Handle(uint IOCTL, ref DeviceData Data, BinaryEmulator Instance)
+        {
+            switch (IOCTL)
+            {
+                case IOCTL_KSEC_RNG:
+                case IOCTL_KSEC_RNG_REKEY:
+                    if (Data.OutputBuffer == null || Data.OutputLength == 0)
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    uint Size = Math.Min(Data.OutputLength, (uint)Data.OutputBuffer.Length);
+                    if (Size == 0)
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    RandomNumberGenerator.Fill(Data.OutputBuffer.AsSpan(0, (int)Size));
+                    Data.Information = Size;
+                    return NTSTATUS.STATUS_SUCCESS;
+
+                case IOCTL_KSEC_ENCRYPT_MEMORY:
+                case IOCTL_KSEC_DECRYPT_MEMORY:
+                case IOCTL_KSEC_ENCRYPT_MEMORY_CROSS_PROCESS:
+                case IOCTL_KSEC_DECRYPT_MEMORY_CROSS_PROCESS:
+                case IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON:
+                case IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON:
+                    {
+                        // RtlEncryptMemory/RtlDecryptMemory: emulate as identity so an encrypt followed
+                        // by a decrypt round-trips to the original plaintext within the emulated process.
+                        byte[] Source = (Data.InputBuffer != null && Data.InputBuffer.Length > 0) ? Data.InputBuffer : Data.OutputBuffer;
+                        if (Data.OutputBuffer != null && Source != null)
+                        {
+                            int Count = Math.Min(Data.OutputBuffer.Length, Source.Length);
+                            if (!ReferenceEquals(Source, Data.OutputBuffer))
+                                Array.Copy(Source, Data.OutputBuffer, Count);
+                            Data.Information = (uint)Count;
+                        }
+                        return NTSTATUS.STATUS_SUCCESS;
+                    }
+
+                case IOCTL_KSEC_CLIENT_HANDSHAKE:
+                    // Acknowledge with success and a zeroed output token so the owning DllMain
+                    // returns TRUE instead of aborting the process with STATUS_DLL_INIT_FAILED.
+                    if (Data.OutputBuffer != null && Data.OutputLength > 0)
+                    {
+                        uint OutN = Math.Min(Data.OutputLength, (uint)Data.OutputBuffer.Length);
+                        Data.OutputBuffer.AsSpan(0, (int)OutN).Clear();
+                        Data.Information = OutN;
+                    }
+                    return NTSTATUS.STATUS_SUCCESS;
+
+                default:
+                    return NTSTATUS.STATUS_INVALID_DEVICE_REQUEST;
+            }
+        }
+    }
+}

--- a/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
@@ -4,11 +4,7 @@ using System.Security.Cryptography;
 namespace Brovan.Core.Emulation.OS.Windows
 {
     /// <summary>
-    /// Emulates <c>\Device\KsecDD</c> (Kernel Security Support Provider device). During process
-    /// initialization bcrypt/CNG (and the CRT) open this device and use it for random number
-    /// generation (IOCTL_KSEC_RNG) and for RtlEncryptMemory/RtlDecryptMemory
-    /// (IOCTL_KSEC_*_MEMORY). If the open fails the owning DllMain returns FALSE and the process
-    /// aborts with STATUS_DLL_INIT_FAILED, so the device must at least be openable.
+    /// Emulates <c>\Device\KsecDD</c> (Kernel Security Support Provider device)
     /// </summary>
     internal sealed class KsecDevice : IWinDevice
     {
@@ -22,8 +18,6 @@ namespace Brovan.Core.Emulation.OS.Windows
         private const uint IOCTL_KSEC_DECRYPT_MEMORY_CROSS_PROCESS = 0x390018;
         private const uint IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON = 0x39001C;
         private const uint IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON = 0x390020;
-        // FILE_DEVICE_KSEC function 0x100 (104-byte input, 8-byte output). bcrypt/CNG issues this
-        // from its DllMain during process init and only requires the call to succeed.
         private const uint IOCTL_KSEC_CLIENT_HANDSHAKE = 0x390400;
 
         public NTSTATUS Create(BinaryEmulator Instance, string DevicePath, byte[] EaBuffer, out string InternalPath, out WinDeviceDelegate Handler)
@@ -57,8 +51,6 @@ namespace Brovan.Core.Emulation.OS.Windows
                 case IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON:
                 case IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON:
                     {
-                        // RtlEncryptMemory/RtlDecryptMemory: emulate as identity so an encrypt followed
-                        // by a decrypt round-trips to the original plaintext within the emulated process.
                         byte[] Source = (Data.InputBuffer != null && Data.InputBuffer.Length > 0) ? Data.InputBuffer : Data.OutputBuffer;
                         if (Data.OutputBuffer != null && Source != null)
                         {
@@ -71,8 +63,6 @@ namespace Brovan.Core.Emulation.OS.Windows
                     }
 
                 case IOCTL_KSEC_CLIENT_HANDSHAKE:
-                    // Acknowledge with success and a zeroed output token so the owning DllMain
-                    // returns TRUE instead of aborting the process with STATUS_DLL_INIT_FAILED.
                     if (Data.OutputBuffer != null && Data.OutputLength > 0)
                     {
                         uint OutN = Math.Min(Data.OutputLength, (uint)Data.OutputBuffer.Length);

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtCreateFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtCreateFile.cs
@@ -31,7 +31,7 @@ namespace Brovan.Core.Emulation.OS.Windows
         private NTSTATUS Handle64(BinaryEmulator Instance)
         {
             ulong FileHandlePtr = Instance.WinHelper.GetArg64(0);
-            ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+            ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
             ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
             ulong IoStatusBlockPtr = Instance.WinHelper.GetArg64(3);
             uint CreateDisposition = (uint)Instance.WinHelper.GetArg64(7);

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtCreateSection.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtCreateSection.cs
@@ -13,7 +13,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong SectionHandlePtr = Instance.WinHelper.GetArg64(0);
-            ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+            ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
             ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
             ulong MaximumSizePtr = Instance.WinHelper.GetArg64(3);
             uint SectionPageProtection = (uint)Instance.WinHelper.GetArg64(4);

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtQueryDirectoryFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtQueryDirectoryFile.cs
@@ -20,9 +20,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             ulong FileInformation = Instance.WinHelper.GetArg64(5);
             uint Length = (uint)Instance.WinHelper.GetArg64(6);
             uint FileInformationClass = (uint)Instance.WinHelper.GetArg64(7);
-            bool ReturnSingleEntry = Instance.WinHelper.GetArg64(8) != 0;
+            bool ReturnSingleEntry = (uint)Instance.WinHelper.GetArg64(8) != 0;
             ulong FileName = Instance.WinHelper.GetArg64(9);
-            bool RestartScan = Instance.WinHelper.GetArg64(10) != 0;
+            bool RestartScan = (uint)Instance.WinHelper.GetArg64(10) != 0;
 
             uint QueryFlags = 0;
             if (RestartScan)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtContinue.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtContinue.cs
@@ -7,7 +7,7 @@ namespace Brovan.Core.Emulation.OS.Windows
         public NTSTATUS Handle(BinaryEmulator Instance)
         {
             ulong ContextPtr = Instance.WinHelper.GetArg64(0);
-            bool TestAlert = Instance.WinHelper.GetArg64(1) != 0;
+            bool TestAlert = (uint)Instance.WinHelper.GetArg64(1) != 0;
 
             return Continue(Instance, ContextPtr, TestAlert);
         }

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateEvent.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateEvent.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong EventHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributes = Instance.WinHelper.GetArg64(2);
                 uint EventType = (uint)Instance.WinHelper.GetArg64(3);
                 bool InitialState = (byte)Instance.WinHelper.GetArg64(4, true) != 0;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateIoCompletion.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateIoCompletion.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong IoCompletionHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong Count = Instance.WinHelper.GetArg64(3);
 
                 if (IoCompletionHandlePtr == 0)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateMutant.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateMutant.cs
@@ -11,9 +11,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong MutantHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
-                bool InitialOwner = Instance.WinHelper.GetArg64(3) != 0;
+                bool InitialOwner = (uint)Instance.WinHelper.GetArg64(3) != 0;
 
                 return HandleCreateMutant64(Instance, MutantHandlePtr, DesiredAccess, ObjectAttributesPtr, InitialOwner);
             }

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateSemaphore.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateSemaphore.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong SemaphoreHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
                 int InitialCount = (int)Instance.WinHelper.GetArg64(3, true);
                 int MaximumCount = (int)Instance.WinHelper.GetArg64(4, true);

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateTimer2.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateTimer2.cs
@@ -11,8 +11,8 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong TimerHandlePtr = Instance.WinHelper.GetArg64(0);
                 ulong TimerIdPtr = Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
-                ulong Attributes = Instance.WinHelper.GetArg64(3);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(4);
+                ulong Attributes = (uint)Instance.WinHelper.GetArg64(3);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(4);
 
                 if (TimerHandlePtr == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateWaitCompletionPacket.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateWaitCompletionPacket.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong WaitCompletionPacketHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributes = Instance.WinHelper.GetArg64(2);
 
                 if (WaitCompletionPacketHandlePtr == 0)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtDelayExecution.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtDelayExecution.cs
@@ -83,7 +83,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture != BinaryArchitecture.x64)
                 return Instance.WinUnimplemented;
 
-            bool Alertable = Instance.WinHelper.GetArg64(0) != 0;
+            bool Alertable = (uint)Instance.WinHelper.GetArg64(0) != 0;
             ulong DelayIntervalPtr = Instance.WinHelper.GetArg64(1);
             long DelayMs = ReadDelayMs(Instance, DelayIntervalPtr);
             EmulatedThread Thread = Instance.CurrentThread;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtDuplicateObject.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtDuplicateObject.cs
@@ -16,7 +16,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong SourceHandle = Instance.WinHelper.GetArg64(1);
                 ulong TargetProcessHandle = Instance.WinHelper.GetArg64(2);
                 ulong TargetHandlePtr = Instance.WinHelper.GetArg64(3);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(4);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(4);
                 uint HandleAttributes = (uint)Instance.WinHelper.GetArg64(5);
                 uint Options = (uint)Instance.WinHelper.GetArg64(6);
 

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenMutant.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenMutant.cs
@@ -11,7 +11,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong MutantHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
 
                 return HandleOpenMutant64(Instance, MutantHandlePtr, DesiredAccess, ObjectAttributesPtr);

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenSemaphore.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenSemaphore.cs
@@ -11,7 +11,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong SemaphoreHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
 
                 return HandleOpenSemaphore64(Instance, SemaphoreHandlePtr, DesiredAccess, ObjectAttributesPtr);

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtRaiseException.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtRaiseException.cs
@@ -17,7 +17,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             ulong ExceptionRecordPtr = Instance.WinHelper.GetArg64(0);
             ulong ContextRecordPtr = Instance.WinHelper.GetArg64(1);
 
-            bool FirstChance = Instance.WinHelper.GetArg64(2) != 0;
+            bool FirstChance = (uint)Instance.WinHelper.GetArg64(2) != 0;
             _ = FirstChance;
 
             if (ExceptionRecordPtr == 0 || ContextRecordPtr == 0)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForMultipleObjects.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForMultipleObjects.cs
@@ -82,7 +82,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             uint Count = (uint)Instance.WinHelper.GetArg64(0);
             ulong HandlesPtr = Instance.WinHelper.GetArg64(1);
             uint WaitType = (uint)Instance.WinHelper.GetArg64(2);
-            bool Alertable = Instance.WinHelper.GetArg64(3) != 0;
+            bool Alertable = (uint)Instance.WinHelper.GetArg64(3) != 0;
             ulong TimeoutPtr = Instance.WinHelper.GetArg64(4);
 
             EmulatedThread Thread = Instance.CurrentThread;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForSingleObject.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForSingleObject.cs
@@ -31,7 +31,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong Handle = Instance.WinHelper.GetArg64(0);
-            bool Alertable = Instance.WinHelper.GetArg64(1) != 0;
+            bool Alertable = (uint)Instance.WinHelper.GetArg64(1) != 0;
             ulong TimeoutPtr = Instance.WinHelper.GetArg64(2);
 
             EmulatedThread Thread = Instance.CurrentThread;

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemory.cs
@@ -7,6 +7,79 @@ namespace Brovan.Core.Emulation.OS.Windows
     {
         private const ulong PageSize = 0x1000;
         private const ulong AllocationGranularity = 0x10000;
+        private const ulong MemReset = 0x00080000UL;
+        private const ulong MemResetUndo = 0x01000000UL;
+
+        private static bool TryApplyResetState(BinaryEmulator Instance, ulong BaseAddress, ulong RegionSize, bool Reset, out NTSTATUS Status)
+        {
+            Status = NTSTATUS.STATUS_SUCCESS;
+
+            if (BaseAddress == 0 || RegionSize == 0)
+            {
+                Status = NTSTATUS.STATUS_INVALID_PARAMETER;
+                return false;
+            }
+
+            if ((BaseAddress & (PageSize - 1)) != 0 || (RegionSize & (PageSize - 1)) != 0)
+            {
+                Status = NTSTATUS.STATUS_CONFLICTING_ADDRESSES;
+                return false;
+            }
+
+            ulong End = BaseAddress + RegionSize;
+            if (End < BaseAddress)
+            {
+                Status = NTSTATUS.STATUS_CONFLICTING_ADDRESSES;
+                return false;
+            }
+
+            ulong Current = BaseAddress;
+            ulong AllocationBase = 0;
+            bool HasAllocationBase = false;
+
+            while (Current < End)
+            {
+                if (!Instance.TryFindMemoryRegionIndex(Current, out int Index) || !Instance.TryFindMemoryRegion(Current, out MemoryRegion Region))
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                if (!Region.IsReserved || !Region.IsCommitted)
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                if (!HasAllocationBase)
+                {
+                    AllocationBase = Region.AllocationBase;
+                    HasAllocationBase = true;
+                }
+                else if (Region.AllocationBase != AllocationBase)
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                ulong RegionEnd = Region.BaseAddress + Region.Size;
+                if (RegionEnd <= Current)
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                if (Region.IsReset != Reset)
+                {
+                    Region.IsReset = Reset;
+                    Instance.SetMemoryRegion(Index, Region);
+                }
+
+                Current = Math.Min(RegionEnd, End);
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// Finds a free base address (allocation granularity aligned) that does not overlap any existing region.
@@ -71,12 +144,32 @@ namespace Brovan.Core.Emulation.OS.Windows
                 if (RegionSizeRaw == 0 || AllocationTypeValue == 0 || ProtectValue == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;
 
-                RegionSize = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
-
                 ulong BaseAddress = Instance.ReadMemoryULong(BaseAddressPtr);
 
                 bool Reserve = (AllocationTypeValue & 0x2000UL) != 0; // MEM_RESERVE
                 bool Commit = (AllocationTypeValue & 0x1000UL) != 0;  // MEM_COMMIT
+
+                bool Reset = (AllocationTypeValue & MemReset) != 0;
+                bool ResetUndo = (AllocationTypeValue & MemResetUndo) != 0;
+                if (Reset || ResetUndo)
+                {
+                    if ((Reset && ResetUndo) || (Reset && AllocationTypeValue != MemReset) || (ResetUndo && AllocationTypeValue != MemResetUndo))
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    ulong ResetRegionSize = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
+                    if (!TryApplyResetState(Instance, BaseAddress, ResetRegionSize, Reset, out NTSTATUS ResetStatus))
+                        return ResetStatus;
+
+                    if (!Instance._emulator.WriteMemory(BaseAddressPtr, BaseAddress))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    if (!Instance._emulator.WriteMemory(RegionSizePtr, ResetRegionSize))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    return NTSTATUS.STATUS_SUCCESS;
+                }
+
+                RegionSize = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
 
                 Instance.TriggerEventMessage($"[+] NtAllocateVirtualMemory (BaseAddress: 0x{BaseAddress:X}, RegionSize: {RegionSize}, Commit: {Commit}, Reserve: {Reserve})", LogFlags.Syscall);
 
@@ -157,13 +250,33 @@ namespace Brovan.Core.Emulation.OS.Windows
                 if (RegionSizeRaw == 0 || AllocationTypeValue == 0 || ProtectValue == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;
 
-                RegionSize = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
-
                 uint BaseAddress32 = Instance.ReadMemoryUInt(BaseAddressPtr);
                 ulong BaseAddress = BaseAddress32;
 
                 bool Reserve = (AllocationTypeValue & 0x2000U) != 0; // MEM_RESERVE
-                bool Commit = (AllocationTypeValue & 0x1000U) != 0;  // MEM_COMMIT
+                bool Commit = (AllocationTypeValue & 0x1000U) != 0; // MEM_COMMIT
+
+                bool Reset = (AllocationTypeValue & MemReset) != 0;
+                bool ResetUndo = (AllocationTypeValue & MemResetUndo) != 0;
+                if (Reset || ResetUndo)
+                {
+                    if ((Reset && ResetUndo) || (Reset && AllocationTypeValue != MemReset) || (ResetUndo && AllocationTypeValue != MemResetUndo))
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    ulong ResetRegionSize = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
+                    if (!TryApplyResetState(Instance, BaseAddress, ResetRegionSize, Reset, out NTSTATUS ResetStatus))
+                        return ResetStatus;
+
+                    if (!Instance._emulator.WriteMemory(BaseAddressPtr, (uint)BaseAddress))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    if (!Instance._emulator.WriteMemory(RegionSizePtr, (uint)ResetRegionSize))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    return NTSTATUS.STATUS_SUCCESS;
+                }
+
+                RegionSize = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
 
                 Instance.TriggerEventMessage($"[+] NtAllocateVirtualMemory (BaseAddress: 0x{BaseAddress:X}, RegionSize: {RegionSize}, Commit: {Commit}, Reserve: {Reserve})", LogFlags.Syscall);
 

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemory.cs
@@ -38,8 +38,8 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong ZeroBits = Instance.WinHelper.GetArg64(2); // ignored for now
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(3);
-                ulong AllocationTypeValue = Instance.WinHelper.GetArg64(4);
-                ulong ProtectValue = Instance.WinHelper.GetArg64(5);
+                ulong AllocationTypeValue = (uint)Instance.WinHelper.GetArg64(4);
+                ulong ProtectValue = (uint)Instance.WinHelper.GetArg64(5);
                 ulong RegionSize = 0;
                 if (ProcessHandle != ulong.MaxValue)
                 {

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemoryEx.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemoryEx.cs
@@ -7,6 +7,8 @@ namespace Brovan.Core.Emulation.OS.Windows
     {
         private const ulong PageSize = 0x1000;
         private const ulong AllocationGranularity = 0x10000;
+        private const ulong MemReset = 0x00080000UL;
+        private const ulong MemResetUndo = 0x01000000UL;
 
         private static ulong FindFreeBaseAddress(BinaryEmulator Instance, ulong Size, bool IsX64)
         {
@@ -26,6 +28,79 @@ namespace Brovan.Core.Emulation.OS.Windows
             return 0;
         }
 
+        private static bool TryApplyResetState(BinaryEmulator Instance, ulong BaseAddress, ulong RegionSize, bool Reset, out NTSTATUS Status)
+        {
+            Status = NTSTATUS.STATUS_SUCCESS;
+
+            if (BaseAddress == 0 || RegionSize == 0)
+            {
+                Status = NTSTATUS.STATUS_INVALID_PARAMETER;
+                return false;
+            }
+
+            if ((BaseAddress & (PageSize - 1)) != 0 || (RegionSize & (PageSize - 1)) != 0)
+            {
+                Status = NTSTATUS.STATUS_CONFLICTING_ADDRESSES;
+                return false;
+            }
+
+            ulong End = BaseAddress + RegionSize;
+            if (End < BaseAddress)
+            {
+                Status = NTSTATUS.STATUS_CONFLICTING_ADDRESSES;
+                return false;
+            }
+
+            ulong Current = BaseAddress;
+            ulong AllocationBase = 0;
+            bool HasAllocationBase = false;
+
+            while (Current < End)
+            {
+                if (!Instance.TryFindMemoryRegionIndex(Current, out int Index) || !Instance.TryFindMemoryRegion(Current, out MemoryRegion Region))
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                if (!Region.IsReserved || !Region.IsCommitted)
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                if (!HasAllocationBase)
+                {
+                    AllocationBase = Region.AllocationBase;
+                    HasAllocationBase = true;
+                }
+                else if (Region.AllocationBase != AllocationBase)
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                ulong RegionEnd = Region.BaseAddress + Region.Size;
+                if (RegionEnd <= Current)
+                {
+                    Status = NTSTATUS.STATUS_MEMORY_NOT_ALLOCATED;
+                    return false;
+                }
+
+                if (Region.IsReset == Reset)
+                {
+                    Current = Math.Min(RegionEnd, End);
+                    continue;
+                }
+
+                Region.IsReset = Reset;
+                Instance.SetMemoryRegion(Index, Region);
+                Current = Math.Min(RegionEnd, End);
+            }
+
+            return true;
+        }
+
         public NTSTATUS Handle(BinaryEmulator Instance)
         {
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
@@ -33,29 +108,16 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(2);
-                // AllocationType, PageProtection and ExtendedParameterCount are ULONG (32-bit) in the
-                // syscall signature; the caller can leave garbage in the upper 32 bits of the register,
-                // so mask to 32 bits. Without this, a real count of 0 with non-zero high bits is read as
-                // non-zero and wrongly fails the "count != 0 but pointer == 0" check (INVALID_PARAMETER).
                 ulong AllocationTypeValue = (uint)Instance.WinHelper.GetArg64(3);
                 ulong ProtectValue = (uint)Instance.WinHelper.GetArg64(4);
                 ulong ExtendedParametersPtr = Instance.WinHelper.GetArg64(5);
                 ulong ExtendedParameterCount = (uint)Instance.WinHelper.GetArg64(6);
-
-                if (ProtectValue == 0x08 || ProtectValue == 0x80)
-                    return NTSTATUS.STATUS_INVALID_PAGE_PROTECTION;
 
                 if (BaseAddressPtr == 0 || RegionSizePtr == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;
 
                 ulong RegionSizeRaw = Instance.ReadMemoryULong(RegionSizePtr);
                 if (RegionSizeRaw == 0 || AllocationTypeValue == 0 || ProtectValue == 0)
-                    return NTSTATUS.STATUS_INVALID_PARAMETER;
-
-                if (ExtendedParameterCount != 0 && ExtendedParametersPtr == 0)
-                    return NTSTATUS.STATUS_INVALID_PARAMETER;
-
-                if (ExtendedParameterCount == 0 && ExtendedParametersPtr != 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;
 
                 if (ProcessHandle != ulong.MaxValue)
@@ -73,16 +135,43 @@ namespace Brovan.Core.Emulation.OS.Windows
                     return Instance.WinUnimplemented;
                 }
 
+                bool Reset = (AllocationTypeValue & MemReset) != 0;
+                bool ResetUndo = (AllocationTypeValue & MemResetUndo) != 0;
+                if (Reset || ResetUndo)
+                {
+                    if ((Reset && ResetUndo) || (Reset && AllocationTypeValue != MemReset) || (ResetUndo && AllocationTypeValue != MemResetUndo))
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    ulong BaseAddressReset = Instance.ReadMemoryULong(BaseAddressPtr);
+                    ulong RegionSizeReset = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
+                    if (!TryApplyResetState(Instance, BaseAddressReset, RegionSizeReset, Reset, out NTSTATUS ResetStatus))
+                        return ResetStatus;
+
+                    if (!Instance._emulator.WriteMemory(BaseAddressPtr, BaseAddressReset))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    if (!Instance._emulator.WriteMemory(RegionSizePtr, RegionSizeReset))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    return NTSTATUS.STATUS_SUCCESS;
+                }
+
                 ulong RegionSize = BinaryEmulator.AlignUp(RegionSizeRaw, PageSize);
                 ulong BaseAddress = Instance.ReadMemoryULong(BaseAddressPtr);
 
                 bool Reserve = (AllocationTypeValue & 0x2000UL) != 0; // MEM_RESERVE
-                bool Commit = (AllocationTypeValue & 0x1000UL) != 0;  // MEM_COMMIT
+                bool Commit = (AllocationTypeValue & 0x1000UL) != 0; // MEM_COMMIT
 
                 Instance.TriggerEventMessage($"[+] NtAllocateVirtualMemoryEx (BaseAddress: 0x{BaseAddress:X}, RegionSize: {RegionSize}, Commit: {Commit}, Reserve: {Reserve})", LogFlags.Syscall);
 
                 if (!Reserve && !Commit)
+                {
+                    if ((AllocationTypeValue & 0x00080000UL) != 0 || // MEM_RESET
+                        (AllocationTypeValue & 0x01000000UL) != 0) // MEM_RESET_UNDO
+                        return Instance.WinUnimplemented;
+
                     return NTSTATUS.STATUS_INVALID_PARAMETER;
+                }
 
                 if (!Reserve && Commit && BaseAddress == 0)
                     Reserve = true;
@@ -138,12 +227,6 @@ namespace Brovan.Core.Emulation.OS.Windows
                 if (RegionSizeRaw32 == 0 || AllocationTypeValue == 0 || ProtectValue == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;
 
-                if (ExtendedParameterCount != 0 && ExtendedParametersPtr == 0)
-                    return NTSTATUS.STATUS_INVALID_PARAMETER;
-
-                if (ExtendedParameterCount == 0 && ExtendedParametersPtr != 0)
-                    return NTSTATUS.STATUS_INVALID_PARAMETER;
-
                 if (ProcessHandle != uint.MaxValue)
                 {
                     if (!Instance.WinHelper.ValidProcessHandle(ProcessHandle))
@@ -157,6 +240,27 @@ namespace Brovan.Core.Emulation.OS.Windows
                         return NTSTATUS.STATUS_ACCESS_DENIED;
 
                     return Instance.WinUnimplemented;
+                }
+
+                bool Reset = (AllocationTypeValue & MemReset) != 0;
+                bool ResetUndo = (AllocationTypeValue & MemResetUndo) != 0;
+                if (Reset || ResetUndo)
+                {
+                    if ((Reset && ResetUndo) || (Reset && AllocationTypeValue != MemReset) || (ResetUndo && AllocationTypeValue != MemResetUndo))
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    ulong BaseAddressReset = Instance.ReadMemoryUInt(BaseAddressPtr);
+                    ulong RegionSizeReset = BinaryEmulator.AlignUp(RegionSizeRaw32, PageSize);
+                    if (!TryApplyResetState(Instance, BaseAddressReset, RegionSizeReset, Reset, out NTSTATUS ResetStatus))
+                        return ResetStatus;
+
+                    if (!Instance._emulator.WriteMemory(BaseAddressPtr, (uint)BaseAddressReset))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    if (!Instance._emulator.WriteMemory(RegionSizePtr, (uint)RegionSizeReset))
+                        return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+                    return NTSTATUS.STATUS_SUCCESS;
                 }
 
                 ulong RegionSize = BinaryEmulator.AlignUp(RegionSizeRaw32, PageSize);

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemoryEx.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemoryEx.cs
@@ -33,10 +33,14 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(2);
-                ulong AllocationTypeValue = Instance.WinHelper.GetArg64(3);
-                ulong ProtectValue = Instance.WinHelper.GetArg64(4);
+                // AllocationType, PageProtection and ExtendedParameterCount are ULONG (32-bit) in the
+                // syscall signature; the caller can leave garbage in the upper 32 bits of the register,
+                // so mask to 32 bits. Without this, a real count of 0 with non-zero high bits is read as
+                // non-zero and wrongly fails the "count != 0 but pointer == 0" check (INVALID_PARAMETER).
+                ulong AllocationTypeValue = (uint)Instance.WinHelper.GetArg64(3);
+                ulong ProtectValue = (uint)Instance.WinHelper.GetArg64(4);
                 ulong ExtendedParametersPtr = Instance.WinHelper.GetArg64(5);
-                ulong ExtendedParameterCount = Instance.WinHelper.GetArg64(6);
+                ulong ExtendedParameterCount = (uint)Instance.WinHelper.GetArg64(6);
 
                 if (ProtectValue == 0x08 || ProtectValue == 0x80)
                     return NTSTATUS.STATUS_INVALID_PAGE_PROTECTION;

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtCreateProcess.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtCreateProcess.cs
@@ -15,7 +15,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong ProcessHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
                 ulong ParentProcess = Instance.WinHelper.GetArg64(3);
                 ulong InheritObjectTable = Instance.WinHelper.GetArg64(4);

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtCreateThreadEx.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtCreateThreadEx.cs
@@ -53,11 +53,11 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong ThreadHandlePtr = Instance.WinHelper.GetArg64(0);
-            ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+            ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
             ulong ProcessHandle = Instance.WinHelper.GetArg64(3);
             ulong StartRoutine = Instance.WinHelper.GetArg64(4);
             ulong Argument = Instance.WinHelper.GetArg64(5);
-            ulong CreateFlags = Instance.WinHelper.GetArg64(6);
+            ulong CreateFlags = (uint)Instance.WinHelper.GetArg64(6);
             ulong StackSize = Instance.WinHelper.GetArg64(8);
             ulong AttributeList = Instance.WinHelper.GetArg64(10);
 

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtCreateWorkerFactory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtCreateWorkerFactory.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong WorkerFactoryHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
                 ulong IoCompletionHandle = Instance.WinHelper.GetArg64(3);
                 ulong WorkerProcessHandle = Instance.WinHelper.GetArg64(4);

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtDuplicateToken.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtDuplicateToken.cs
@@ -24,9 +24,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Is64)
             {
                 ExistingTokenHandle = Instance.WinHelper.GetArg64(0);
-                DesiredAccess = Instance.WinHelper.GetArg64(1);
+                DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
-                EffectiveOnly = Instance.WinHelper.GetArg64(3) != 0;
+                EffectiveOnly = (uint)Instance.WinHelper.GetArg64(3) != 0;
                 RequestedTokenType = (uint)Instance.WinHelper.GetArg64(4);
                 NewTokenHandlePtr = Instance.WinHelper.GetArg64(5);
             }

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtFreeVirtualMemory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtFreeVirtualMemory.cs
@@ -17,7 +17,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(2);
-                ulong FreeType = Instance.WinHelper.GetArg64(3);
+                ulong FreeType = (uint)Instance.WinHelper.GetArg64(3);
 
                 if (BaseAddressPtr == 0 || RegionSizePtr == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtOpenProcessToken.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtOpenProcessToken.cs
@@ -16,7 +16,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Is64)
             {
                 ProcessHandle = Instance.WinHelper.GetArg64(0);
-                DesiredAccess = Instance.WinHelper.GetArg64(1);
+                DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 TokenHandlePtr = Instance.WinHelper.GetArg64(2);
 
                 if (TokenHandlePtr == 0 || !Instance.IsRegionMapped(TokenHandlePtr, 8))

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtProtectVirtualMemory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtProtectVirtualMemory.cs
@@ -16,7 +16,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(2);
-                ulong NewProtection = Instance.WinHelper.GetArg64(3);
+                ulong NewProtection = (uint)Instance.WinHelper.GetArg64(3);
                 ulong OldProtectionPtr = Instance.WinHelper.GetArg64(4);
 
                 // current process

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtQuerySystemInformationEx.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtQuerySystemInformationEx.cs
@@ -10,11 +10,13 @@ namespace Brovan.Core.Emulation.OS.Windows
         {
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
-                SYSTEM_INFORMATION_CLASS SystemInformationClass = (SYSTEM_INFORMATION_CLASS)Instance.WinHelper.GetArg64(0);
+                // SystemInformationClass, InputBufferLength and SystemInformationLength are ULONG (32-bit);
+                // mask to 32 bits since the caller can leave garbage in the upper half of the (stack-passed) slots.
+                SYSTEM_INFORMATION_CLASS SystemInformationClass = (SYSTEM_INFORMATION_CLASS)(uint)Instance.WinHelper.GetArg64(0);
                 ulong InputBufferPtr = Instance.WinHelper.GetArg64(1);
-                ulong InputBufferLength = Instance.WinHelper.GetArg64(2);
+                ulong InputBufferLength = (uint)Instance.WinHelper.GetArg64(2);
                 ulong SystemInformationPtr = Instance.WinHelper.GetArg64(3);
-                ulong SystemInformationLength = Instance.WinHelper.GetArg64(4);
+                ulong SystemInformationLength = (uint)Instance.WinHelper.GetArg64(4);
                 ulong ReturnLengthPtr = Instance.WinHelper.GetArg64(5);
 
                 if (InputBufferLength != 0)

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateProcess.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateProcess.cs
@@ -14,7 +14,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
-                ulong ExitCode = Instance.WinHelper.GetArg64(1);
+                ulong ExitCode = (uint)Instance.WinHelper.GetArg64(1);
 
                 if (ExitCode == 0)
                 {

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateThread.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateThread.cs
@@ -10,7 +10,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong ThreadHandle = Instance.WinHelper.GetArg64(0);
-            ulong ExitStatus = Instance.WinHelper.GetArg64(1);
+            ulong ExitStatus = (uint)Instance.WinHelper.GetArg64(1);
 
             bool TerminatingSelfByNullHandle = ThreadHandle == 0;
             EmulatedThread TargetThread = null;

--- a/Brovan/Core/Emulation/OS/Windows/Win32k/NtUserMessageCall.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Win32k/NtUserMessageCall.cs
@@ -14,7 +14,7 @@ namespace Brovan.Core.Emulation.OS.Windows.Win32k
             ulong WParam = Instance.WinHelper.GetArg64(2);
             ulong LParam = Instance.WinHelper.GetArg64(3);
             ulong XParam = Instance.WinHelper.GetArg64(4);
-            ulong Flags = Instance.WinHelper.GetArg64(6);
+            ulong Flags = (uint)Instance.WinHelper.GetArg64(6);
             bool Ansi = (XParam & 1) != 0 || (Flags & 1) != 0;
 
             if ((Message & 0xFFFE0000u) != 0)


### PR DESCRIPTION
This fixes the issue I faced when testing where my ntdll version was newer, I think, so the process aborted during initialization and never reached main. Two root causes:

  - \Device\KsecDD wasn't emulated. bcrypt/CNG opens this device from its DllMain during process init; the failed open made the DllMain return FALSE, so the loader aborted the whole process with STATUS_DLL_INIT_FAILED.
  - Several 32‑bit (ULONG) syscall arguments were read as 64‑bit. Per the x64 syscall ABI the upper 32 bits of a 32‑bit argument are undefined, and on newer ntdll builds they contain garbage. Reading them as full 64‑bit values made handler checks (e.g. count != 0, protection/flag comparisons) see bogus values and return spurious errors like STATUS_INVALID_PARAMETER.

Can you please verify before merge?