### PR TITLE
Add \Device\KsecDD emulation and mask 32-bit syscall arguments

### DIFF
--- a/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Brovan.Core.Emulation.OS.Windows
+{
+    internal sealed class KsecDevice : IWinDevice
+    {
+        public string DeviceName => "\\Device\\KsecDD";
+
+        private const uint IOCTL_KSEC_RNG = 0x390004;
+        private const uint IOCTL_KSEC_RNG_REKEY = 0x390008;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY = 0x39000C;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY = 0x390010;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_CROSS_PROCESS = 0x390014;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY_CROSS_PROCESS = 0x390018;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON = 0x39001C;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON = 0x390020;
+        private const uint IOCTL_KSEC_CLIENT_HANDSHAKE = 0x390400;
+
+        public NTSTATUS Create(BinaryEmulator Instance, string DevicePath, byte[] EaBuffer, out string InternalPath, out WinDeviceDelegate Handler)
+        {
+            InternalPath = DevicePath;
+            Handler = Handle;
+            return NTSTATUS.STATUS_SUCCESS;
+        }
+
+        private NTSTATUS Handle(uint IOCTL, ref DeviceData Data, BinaryEmulator Instance)
+        {
+            switch (IOCTL)
+            {
+                case IOCTL_KSEC_RNG:
+                case IOCTL_KSEC_RNG_REKEY:
+                    if (Data.OutputBuffer == null || Data.OutputLength == 0)
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    uint Size = Math.Min(Data.OutputLength, (uint)Data.OutputBuffer.Length);
+                    if (Size == 0)
+                        return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+                    RandomNumberGenerator.Fill(Data.OutputBuffer.AsSpan(0, (int)Size));
+                    Data.Information = Size;
+                    return NTSTATUS.STATUS_SUCCESS;
+
+                case IOCTL_KSEC_ENCRYPT_MEMORY:
+                case IOCTL_KSEC_DECRYPT_MEMORY:
+                case IOCTL_KSEC_ENCRYPT_MEMORY_CROSS_PROCESS:
+                case IOCTL_KSEC_DECRYPT_MEMORY_CROSS_PROCESS:
+                case IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON:
+                case IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON:
+                    {
+                        byte[] Source = (Data.InputBuffer != null && Data.InputBuffer.Length > 0) ? Data.InputBuffer : Data.OutputBuffer;
+                        if (Data.OutputBuffer != null && Source != null)
+                        {
+                            int Count = Math.Min(Data.OutputBuffer.Length, Source.Length);
+                            if (!ReferenceEquals(Source, Data.OutputBuffer))
+                                Array.Copy(Source, Data.OutputBuffer, Count);
+                            Data.Information = (uint)Count;
+                        }
+                        return NTSTATUS.STATUS_SUCCESS;
+                    }
+
+                case IOCTL_KSEC_CLIENT_HANDSHAKE:
+                    if (Data.OutputBuffer != null && Data.OutputLength > 0)
+                    {
+                        uint OutN = Math.Min(Data.OutputLength, (uint)Data.OutputBuffer.Length);
+                        Data.OutputBuffer.AsSpan(0, (int)OutN).Clear();
+                        Data.Information = OutN;
+                    }
+                    return NTSTATUS.STATUS_SUCCESS;
+
+                default:
+                    return NTSTATUS.STATUS_INVALID_DEVICE_REQUEST;
+            }
+        }
+    }
+}

--- a/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Devices/KsecDevice.cs
@@ -9,12 +9,12 @@ namespace Brovan.Core.Emulation.OS.Windows
 
         private const uint IOCTL_KSEC_RNG = 0x390004;
         private const uint IOCTL_KSEC_RNG_REKEY = 0x390008;
-        private const uint IOCTL_KSEC_ENCRYPT_MEMORY = 0x39000C;
-        private const uint IOCTL_KSEC_DECRYPT_MEMORY = 0x390010;
-        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_CROSS_PROCESS = 0x390014;
-        private const uint IOCTL_KSEC_DECRYPT_MEMORY_CROSS_PROCESS = 0x390018;
-        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON = 0x39001C;
-        private const uint IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON = 0x390020;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY = 0x39000E;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY = 0x390012;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_CROSS_PROCESS = 0x390016;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY_CROSS_PROCESS = 0x39001A;
+        private const uint IOCTL_KSEC_ENCRYPT_MEMORY_SAME_LOGON = 0x39001E;
+        private const uint IOCTL_KSEC_DECRYPT_MEMORY_SAME_LOGON = 0x390022;
         private const uint IOCTL_KSEC_CLIENT_HANDSHAKE = 0x390400;
 
         public NTSTATUS Create(BinaryEmulator Instance, string DevicePath, byte[] EaBuffer, out string InternalPath, out WinDeviceDelegate Handler)

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtCreateFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtCreateFile.cs
@@ -31,7 +31,7 @@ namespace Brovan.Core.Emulation.OS.Windows
         private NTSTATUS Handle64(BinaryEmulator Instance)
         {
             ulong FileHandlePtr = Instance.WinHelper.GetArg64(0);
-            ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+            ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
             ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
             ulong IoStatusBlockPtr = Instance.WinHelper.GetArg64(3);
             uint CreateDisposition = (uint)Instance.WinHelper.GetArg64(7);

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtCreateSection.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtCreateSection.cs
@@ -13,7 +13,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong SectionHandlePtr = Instance.WinHelper.GetArg64(0);
-            ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+            ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
             ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
             ulong MaximumSizePtr = Instance.WinHelper.GetArg64(3);
             uint SectionPageProtection = (uint)Instance.WinHelper.GetArg64(4);

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtQueryDirectoryFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtQueryDirectoryFile.cs
@@ -20,9 +20,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             ulong FileInformation = Instance.WinHelper.GetArg64(5);
             uint Length = (uint)Instance.WinHelper.GetArg64(6);
             uint FileInformationClass = (uint)Instance.WinHelper.GetArg64(7);
-            bool ReturnSingleEntry = Instance.WinHelper.GetArg64(8) != 0;
+            bool ReturnSingleEntry = (uint)Instance.WinHelper.GetArg64(8) != 0;
             ulong FileName = Instance.WinHelper.GetArg64(9);
-            bool RestartScan = Instance.WinHelper.GetArg64(10) != 0;
+            bool RestartScan = (uint)Instance.WinHelper.GetArg64(10) != 0;
 
             uint QueryFlags = 0;
             if (RestartScan)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtContinue.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtContinue.cs
@@ -7,7 +7,7 @@ namespace Brovan.Core.Emulation.OS.Windows
         public NTSTATUS Handle(BinaryEmulator Instance)
         {
             ulong ContextPtr = Instance.WinHelper.GetArg64(0);
-            bool TestAlert = Instance.WinHelper.GetArg64(1) != 0;
+            bool TestAlert = (uint)Instance.WinHelper.GetArg64(1) != 0;
 
             return Continue(Instance, ContextPtr, TestAlert);
         }

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateEvent.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateEvent.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong EventHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributes = Instance.WinHelper.GetArg64(2);
                 uint EventType = (uint)Instance.WinHelper.GetArg64(3);
                 bool InitialState = (byte)Instance.WinHelper.GetArg64(4, true) != 0;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateIoCompletion.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateIoCompletion.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong IoCompletionHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong Count = Instance.WinHelper.GetArg64(3);
 
                 if (IoCompletionHandlePtr == 0)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateMutant.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateMutant.cs
@@ -11,9 +11,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong MutantHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
-                bool InitialOwner = Instance.WinHelper.GetArg64(3) != 0;
+                bool InitialOwner = (uint)Instance.WinHelper.GetArg64(3) != 0;
 
                 return HandleCreateMutant64(Instance, MutantHandlePtr, DesiredAccess, ObjectAttributesPtr, InitialOwner);
             }

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateSemaphore.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateSemaphore.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong SemaphoreHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
                 int InitialCount = (int)Instance.WinHelper.GetArg64(3, true);
                 int MaximumCount = (int)Instance.WinHelper.GetArg64(4, true);

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateTimer2.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateTimer2.cs
@@ -11,8 +11,8 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong TimerHandlePtr = Instance.WinHelper.GetArg64(0);
                 ulong TimerIdPtr = Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
-                ulong Attributes = Instance.WinHelper.GetArg64(3);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(4);
+                ulong Attributes = (uint)Instance.WinHelper.GetArg64(3);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(4);
 
                 if (TimerHandlePtr == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateWaitCompletionPacket.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtCreateWaitCompletionPacket.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong WaitCompletionPacketHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributes = Instance.WinHelper.GetArg64(2);
 
                 if (WaitCompletionPacketHandlePtr == 0)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtDelayExecution.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtDelayExecution.cs
@@ -83,7 +83,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture != BinaryArchitecture.x64)
                 return Instance.WinUnimplemented;
 
-            bool Alertable = Instance.WinHelper.GetArg64(0) != 0;
+            bool Alertable = (uint)Instance.WinHelper.GetArg64(0) != 0;
             ulong DelayIntervalPtr = Instance.WinHelper.GetArg64(1);
             long DelayMs = ReadDelayMs(Instance, DelayIntervalPtr);
             EmulatedThread Thread = Instance.CurrentThread;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtDuplicateObject.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtDuplicateObject.cs
@@ -16,7 +16,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong SourceHandle = Instance.WinHelper.GetArg64(1);
                 ulong TargetProcessHandle = Instance.WinHelper.GetArg64(2);
                 ulong TargetHandlePtr = Instance.WinHelper.GetArg64(3);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(4);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(4);
                 uint HandleAttributes = (uint)Instance.WinHelper.GetArg64(5);
                 uint Options = (uint)Instance.WinHelper.GetArg64(6);
 

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenMutant.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenMutant.cs
@@ -11,7 +11,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong MutantHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
 
                 return HandleOpenMutant64(Instance, MutantHandlePtr, DesiredAccess, ObjectAttributesPtr);

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenSemaphore.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtOpenSemaphore.cs
@@ -11,7 +11,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong SemaphoreHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
 
                 return HandleOpenSemaphore64(Instance, SemaphoreHandlePtr, DesiredAccess, ObjectAttributesPtr);

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtRaiseException.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtRaiseException.cs
@@ -17,7 +17,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             ulong ExceptionRecordPtr = Instance.WinHelper.GetArg64(0);
             ulong ContextRecordPtr = Instance.WinHelper.GetArg64(1);
 
-            bool FirstChance = Instance.WinHelper.GetArg64(2) != 0;
+            bool FirstChance = (uint)Instance.WinHelper.GetArg64(2) != 0;
             _ = FirstChance;
 
             if (ExceptionRecordPtr == 0 || ContextRecordPtr == 0)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForMultipleObjects.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForMultipleObjects.cs
@@ -82,7 +82,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             uint Count = (uint)Instance.WinHelper.GetArg64(0);
             ulong HandlesPtr = Instance.WinHelper.GetArg64(1);
             uint WaitType = (uint)Instance.WinHelper.GetArg64(2);
-            bool Alertable = Instance.WinHelper.GetArg64(3) != 0;
+            bool Alertable = (uint)Instance.WinHelper.GetArg64(3) != 0;
             ulong TimeoutPtr = Instance.WinHelper.GetArg64(4);
 
             EmulatedThread Thread = Instance.CurrentThread;

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForSingleObject.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtWaitForSingleObject.cs
@@ -31,7 +31,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong Handle = Instance.WinHelper.GetArg64(0);
-            bool Alertable = Instance.WinHelper.GetArg64(1) != 0;
+            bool Alertable = (uint)Instance.WinHelper.GetArg64(1) != 0;
             ulong TimeoutPtr = Instance.WinHelper.GetArg64(2);
 
             EmulatedThread Thread = Instance.CurrentThread;

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemory.cs
@@ -111,8 +111,8 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong ZeroBits = Instance.WinHelper.GetArg64(2); // ignored for now
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(3);
-                ulong AllocationTypeValue = Instance.WinHelper.GetArg64(4);
-                ulong ProtectValue = Instance.WinHelper.GetArg64(5);
+                ulong AllocationTypeValue = (uint)Instance.WinHelper.GetArg64(4);
+                ulong ProtectValue = (uint)Instance.WinHelper.GetArg64(5);
                 ulong RegionSize = 0;
                 if (ProcessHandle != ulong.MaxValue)
                 {

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemoryEx.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtAllocateVirtualMemoryEx.cs
@@ -108,10 +108,10 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(2);
-                ulong AllocationTypeValue = Instance.WinHelper.GetArg64(3);
-                ulong ProtectValue = Instance.WinHelper.GetArg64(4);
+                ulong AllocationTypeValue = (uint)Instance.WinHelper.GetArg64(3);
+                ulong ProtectValue = (uint)Instance.WinHelper.GetArg64(4);
                 ulong ExtendedParametersPtr = Instance.WinHelper.GetArg64(5);
-                ulong ExtendedParameterCount = Instance.WinHelper.GetArg64(6);
+                ulong ExtendedParameterCount = (uint)Instance.WinHelper.GetArg64(6);
 
                 if (BaseAddressPtr == 0 || RegionSizePtr == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtCreateProcess.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtCreateProcess.cs
@@ -15,7 +15,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong ProcessHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
                 ulong ParentProcess = Instance.WinHelper.GetArg64(3);
                 ulong InheritObjectTable = Instance.WinHelper.GetArg64(4);

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtCreateThreadEx.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtCreateThreadEx.cs
@@ -53,11 +53,11 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong ThreadHandlePtr = Instance.WinHelper.GetArg64(0);
-            ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+            ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
             ulong ProcessHandle = Instance.WinHelper.GetArg64(3);
             ulong StartRoutine = Instance.WinHelper.GetArg64(4);
             ulong Argument = Instance.WinHelper.GetArg64(5);
-            ulong CreateFlags = Instance.WinHelper.GetArg64(6);
+            ulong CreateFlags = (uint)Instance.WinHelper.GetArg64(6);
             ulong StackSize = Instance.WinHelper.GetArg64(8);
             ulong AttributeList = Instance.WinHelper.GetArg64(10);
 

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtCreateWorkerFactory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtCreateWorkerFactory.cs
@@ -9,7 +9,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong WorkerFactoryHandlePtr = Instance.WinHelper.GetArg64(0);
-                ulong DesiredAccess = Instance.WinHelper.GetArg64(1);
+                ulong DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ulong ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
                 ulong IoCompletionHandle = Instance.WinHelper.GetArg64(3);
                 ulong WorkerProcessHandle = Instance.WinHelper.GetArg64(4);

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtDuplicateToken.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtDuplicateToken.cs
@@ -24,9 +24,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Is64)
             {
                 ExistingTokenHandle = Instance.WinHelper.GetArg64(0);
-                DesiredAccess = Instance.WinHelper.GetArg64(1);
+                DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 ObjectAttributesPtr = Instance.WinHelper.GetArg64(2);
-                EffectiveOnly = Instance.WinHelper.GetArg64(3) != 0;
+                EffectiveOnly = (uint)Instance.WinHelper.GetArg64(3) != 0;
                 RequestedTokenType = (uint)Instance.WinHelper.GetArg64(4);
                 NewTokenHandlePtr = Instance.WinHelper.GetArg64(5);
             }

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtFreeVirtualMemory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtFreeVirtualMemory.cs
@@ -17,7 +17,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(2);
-                ulong FreeType = Instance.WinHelper.GetArg64(3);
+                ulong FreeType = (uint)Instance.WinHelper.GetArg64(3);
 
                 if (BaseAddressPtr == 0 || RegionSizePtr == 0)
                     return NTSTATUS.STATUS_INVALID_PARAMETER;

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtOpenProcessToken.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtOpenProcessToken.cs
@@ -16,7 +16,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Is64)
             {
                 ProcessHandle = Instance.WinHelper.GetArg64(0);
-                DesiredAccess = Instance.WinHelper.GetArg64(1);
+                DesiredAccess = (uint)Instance.WinHelper.GetArg64(1);
                 TokenHandlePtr = Instance.WinHelper.GetArg64(2);
 
                 if (TokenHandlePtr == 0 || !Instance.IsRegionMapped(TokenHandlePtr, 8))

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtProtectVirtualMemory.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtProtectVirtualMemory.cs
@@ -16,7 +16,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
                 ulong BaseAddressPtr = Instance.WinHelper.GetArg64(1);
                 ulong RegionSizePtr = Instance.WinHelper.GetArg64(2);
-                ulong NewProtection = Instance.WinHelper.GetArg64(3);
+                ulong NewProtection = (uint)Instance.WinHelper.GetArg64(3);
                 ulong OldProtectionPtr = Instance.WinHelper.GetArg64(4);
 
                 // current process

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtQuerySystemInformationEx.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtQuerySystemInformationEx.cs
@@ -10,11 +10,11 @@ namespace Brovan.Core.Emulation.OS.Windows
         {
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
-                SYSTEM_INFORMATION_CLASS SystemInformationClass = (SYSTEM_INFORMATION_CLASS)Instance.WinHelper.GetArg64(0);
+                SYSTEM_INFORMATION_CLASS SystemInformationClass = (SYSTEM_INFORMATION_CLASS)(uint)Instance.WinHelper.GetArg64(0);
                 ulong InputBufferPtr = Instance.WinHelper.GetArg64(1);
-                ulong InputBufferLength = Instance.WinHelper.GetArg64(2);
+                ulong InputBufferLength = (uint)Instance.WinHelper.GetArg64(2);
                 ulong SystemInformationPtr = Instance.WinHelper.GetArg64(3);
-                ulong SystemInformationLength = Instance.WinHelper.GetArg64(4);
+                ulong SystemInformationLength = (uint)Instance.WinHelper.GetArg64(4);
                 ulong ReturnLengthPtr = Instance.WinHelper.GetArg64(5);
 
                 if (InputBufferLength != 0)

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateProcess.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateProcess.cs
@@ -14,7 +14,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance._binary.Architecture == BinaryArchitecture.x64)
             {
                 ulong ProcessHandle = Instance.WinHelper.GetArg64(0);
-                ulong ExitCode = Instance.WinHelper.GetArg64(1);
+                ulong ExitCode = (uint)Instance.WinHelper.GetArg64(1);
 
                 if (ExitCode == 0)
                 {

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateThread.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateThread.cs
@@ -10,7 +10,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return Instance.WinUnimplemented;
 
             ulong ThreadHandle = Instance.WinHelper.GetArg64(0);
-            ulong ExitStatus = Instance.WinHelper.GetArg64(1);
+            ulong ExitStatus = (uint)Instance.WinHelper.GetArg64(1);
 
             bool TerminatingSelfByNullHandle = ThreadHandle == 0;
             EmulatedThread TargetThread = null;

--- a/Brovan/Core/Emulation/OS/Windows/Win32k/NtUserMessageCall.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Win32k/NtUserMessageCall.cs
@@ -14,7 +14,7 @@ namespace Brovan.Core.Emulation.OS.Windows.Win32k
             ulong WParam = Instance.WinHelper.GetArg64(2);
             ulong LParam = Instance.WinHelper.GetArg64(3);
             ulong XParam = Instance.WinHelper.GetArg64(4);
-            ulong Flags = Instance.WinHelper.GetArg64(6);
+            ulong Flags = (uint)Instance.WinHelper.GetArg64(6);
             bool Ansi = (XParam & 1) != 0 || (Flags & 1) != 0;
 
             if ((Message & 0xFFFE0000u) != 0)


### PR DESCRIPTION
- Emulate \Device\KsecDD (RNG + memory encrypt/decrypt) so the bcrypt/CNG DllMain succeeds during Windows PE process initialization.
- Mask ULONG syscall arguments that were read as 64-bit; some ntdll builds leave garbage in the upper 32 bits, which broke handler argument checks.