### PR TITLE
Add IO completion port syscall support

### DIFF
--- a/Brovan/Core/Emulation/BinaryEmulator.cs
+++ b/Brovan/Core/Emulation/BinaryEmulator.cs
@@ -2741,7 +2741,11 @@ namespace Brovan.Core.Emulation
 
             ulong Rip = ReadRegister(IPRegister);
             if ((Settings.Flags & LogFlags.Issues) != 0)
-                TriggerEventMessage($"[-] Invalid memory {GetAction(Type)} related to the address 0x{Address:X} at 0x{Rip:X}.", LogFlags.Issues);
+            {
+                TriggerEventMessage($"[-] Invalid memory {GetAction(Type)} related to the address 0x{Address:X} at {(WinHelper != null ? DescribeAddress(Rip) : $"0x{Rip:X}")}.", LogFlags.Issues);
+                if (WinHelper != null)
+                    TraceStackModuleFrames("[-] Invalid memory");
+            }
 
             bool Continue = false;
             if (Settings.InvalidOperationsCallback != null)

--- a/Brovan/Core/Emulation/Guests/WindowsGuest.cs
+++ b/Brovan/Core/Emulation/Guests/WindowsGuest.cs
@@ -309,6 +309,12 @@ namespace Brovan.Core.Emulation.Guests
             if (Obj is WinWorkerFactory Factory)
                 return IsWorkerFactoryReady(Instance, Factory);
 
+            if (Obj is WinIoCompletion Completion)
+            {
+                Instance.MaterializeSignaledWaitPackets(Handle);
+                return Completion.Entries.Count > 0;
+            }
+
             return false;
         }
 

--- a/Brovan/Core/Emulation/Guests/WindowsGuest.cs
+++ b/Brovan/Core/Emulation/Guests/WindowsGuest.cs
@@ -331,6 +331,12 @@ namespace Brovan.Core.Emulation.Guests
                 return;
             }
 
+            if (State.IoCompletionWaitActive)
+            {
+                CompleteIoCompletionWait(Instance, Thread, State);
+                return;
+            }
+
             NTSTATUS WaitStatus = State.WaitStatus;
             if (WaitStatus == NTSTATUS.STATUS_PENDING)
                 WaitStatus = NTSTATUS.STATUS_SUCCESS;
@@ -365,6 +371,49 @@ namespace Brovan.Core.Emulation.Guests
             State.MsgWaitActive = false;
             State.MsgWaitMask = 0;
             State.GetMessageWaitActive = false;
+            Thread.WaitTimedOut = false;
+            Thread.WaitSatisfiedIndex = -1;
+
+            if (Instance.CurrentThread == Thread)
+            {
+                Instance.WriteRegister(Registers.UC_X86_REG_RIP, Thread.Context.RIP);
+                Instance.WriteRegister(Registers.UC_X86_REG_RAX, Thread.Context.RAX);
+            }
+        }
+
+        private void CompleteIoCompletionWait(BinaryEmulator Instance, EmulatedThread Thread, WindowsThreadState State)
+        {
+            NTSTATUS WaitStatus = NTSTATUS.STATUS_TIMEOUT;
+            WinIoCompletionEntry Entry = State.IoCompletionReservedEntry;
+
+            if (Entry != null && WinHelper != null)
+            {
+                WinHelper.WritePointer(State.IoCompletionKeyContextPtr, Entry.KeyContext);
+                WinHelper.WritePointer(State.IoCompletionApcContextPtr, Entry.ApcContext);
+                WinHelper.WriteIoStatusBlock(Instance, State.IoCompletionIoStatusBlockPtr, Entry.IoStatus, Entry.IoStatusInformation);
+                WaitStatus = NTSTATUS.STATUS_SUCCESS;
+            }
+
+            if (Thread.Context == null)
+                Thread.Context = new CpuContext();
+
+            ulong ResumeRip = State.WaitReturnRIP != 0 ? State.WaitReturnRIP : (State.WaitResumeRIP != 0 ? State.WaitResumeRIP + 2 : Thread.Context.RIP);
+            Thread.Context.RIP = ResumeRip;
+            Thread.Context.RAX = (ulong)(uint)WaitStatus;
+
+            State.IoCompletionWaitActive = false;
+            State.IoCompletionHandle = 0;
+            State.IoCompletionKeyContextPtr = 0;
+            State.IoCompletionApcContextPtr = 0;
+            State.IoCompletionIoStatusBlockPtr = 0;
+            State.IoCompletionReservedEntry = null;
+            State.WaitCompleted = false;
+            State.WaitStatus = WaitStatus;
+            State.WaitResumeRIP = 0;
+            State.WaitReturnRIP = 0;
+            State.WaitAlertable = false;
+            State.WaitObjects = null;
+            State.ApcAlertable = false;
             Thread.WaitTimedOut = false;
             Thread.WaitSatisfiedIndex = -1;
 

--- a/Brovan/Core/Emulation/OS/Windows/BinaryEmulator.WindowsBridge.cs
+++ b/Brovan/Core/Emulation/OS/Windows/BinaryEmulator.WindowsBridge.cs
@@ -436,7 +436,10 @@ namespace Brovan.Core.Emulation
                     continue;
 
                 WindowsThreadState State = WinEmulatedThread.TryGetState(Thread);
-                if (State == null || !State.WorkerFactoryWaitActive)
+                if (State == null)
+                    continue;
+
+                if (!State.WorkerFactoryWaitActive && (Thread.WaitHandles == null || !Thread.WaitHandles.Contains(TargetObjectHandle)))
                     continue;
 
                 if (!TrySatisfyThreadWait(Thread))

--- a/Brovan/Core/Emulation/OS/Windows/BinaryEmulator.WindowsBridge.cs
+++ b/Brovan/Core/Emulation/OS/Windows/BinaryEmulator.WindowsBridge.cs
@@ -318,7 +318,7 @@ namespace Brovan.Core.Emulation
 
             long Now = EmulatedTickCount64;
             long BestDelta = long.MaxValue;
-            bool HasWorkerFactoryWaiter = false;
+            bool HasCompletionPacketWaiter = false;
 
             foreach (EmulatedThread Thread in Threads.Values)
             {
@@ -326,15 +326,15 @@ namespace Brovan.Core.Emulation
                     continue;
 
                 WindowsThreadState State = WinEmulatedThread.TryGetState(Thread);
-                if (State != null && State.WorkerFactoryWaitActive)
+                if (State != null && (State.WorkerFactoryWaitActive || State.IoCompletionWaitActive))
                 {
-                    HasWorkerFactoryWaiter = true;
+                    HasCompletionPacketWaiter = true;
                     break;
                 }
             }
 
             WinHelper.HandleManager.SnapshotHandles(WindowsNextTimerHandleSnapshot);
-            if (HasWorkerFactoryWaiter)
+            if (HasCompletionPacketWaiter)
                 WinHelper.HandleManager.SnapshotHandles(WindowsNextTimerPacketSnapshot);
             else
                 WindowsNextTimerPacketSnapshot.Clear();
@@ -359,7 +359,7 @@ namespace Brovan.Core.Emulation
                 }
 
                 bool HasWorkerFactoryTimerWaiter = false;
-                if (HasWorkerFactoryWaiter)
+                if (HasCompletionPacketWaiter)
                 {
                     for (int PacketIndex = 0; PacketIndex < WindowsNextTimerPacketSnapshot.Count; PacketIndex++)
                     {
@@ -439,7 +439,8 @@ namespace Brovan.Core.Emulation
                 if (State == null)
                     continue;
 
-                if (!State.WorkerFactoryWaitActive && (Thread.WaitHandles == null || !Thread.WaitHandles.Contains(TargetObjectHandle)))
+                if (!State.WorkerFactoryWaitActive && !State.IoCompletionWaitActive
+                    && (Thread.WaitHandles == null || !Thread.WaitHandles.Contains(TargetObjectHandle)))
                     continue;
 
                 if (!TrySatisfyThreadWait(Thread))
@@ -491,6 +492,41 @@ namespace Brovan.Core.Emulation
 
                 Packet.QueuedCompletion = true;
             }
+        }
+
+        internal void ReleaseWaitCompletionPacket(WinIoCompletionEntry Entry)
+        {
+            if (Entry == null || Entry.WaitCompletionPacketHandle == 0 || WinHelper == null)
+                return;
+
+            WinWaitCompletionPacket Packet = WinHelper.HandleManager.GetObjectByHandle<WinWaitCompletionPacket>(Entry.WaitCompletionPacketHandle);
+            if (Packet == null)
+                return;
+
+            Packet.Associated = false;
+            Packet.QueuedCompletion = false;
+        }
+
+        private bool TryReserveIoCompletionEntry(WindowsThreadState State)
+        {
+            State.IoCompletionReservedEntry = null;
+
+            if (WinHelper == null)
+                return false;
+
+            WinIoCompletion Completion = WinHelper.HandleManager.GetObjectByHandle<WinIoCompletion>(State.IoCompletionHandle);
+            if (Completion == null)
+                return false;
+
+            MaterializeSignaledWaitPackets(State.IoCompletionHandle);
+
+            if (Completion.Entries.Count == 0)
+                return false;
+
+            WinIoCompletionEntry Entry = Completion.Entries.Dequeue();
+            ReleaseWaitCompletionPacket(Entry);
+            State.IoCompletionReservedEntry = Entry;
+            return true;
         }
 
         private bool ReserveWorkerFactoryEntries(ulong WorkerFactoryHandle, uint MaxPackets, List<WinIoCompletionEntry> Reserved)
@@ -558,6 +594,23 @@ namespace Brovan.Core.Emulation
                         Thread.WaitSatisfiedIndex = 0;
                         return true;
                     }
+                }
+
+                if (IsEmulatedDeadlineExpired(Thread.WaitDeadline))
+                {
+                    Thread.WaitTimedOut = true;
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (State != null && State.IoCompletionWaitActive)
+            {
+                if (TryReserveIoCompletionEntry(State))
+                {
+                    Thread.WaitSatisfiedIndex = 0;
+                    return true;
                 }
 
                 if (IsEmulatedDeadlineExpired(Thread.WaitDeadline))

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtDeviceIoControlFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtDeviceIoControlFile.cs
@@ -111,6 +111,9 @@ namespace Brovan.Core.Emulation.OS.Windows
                     Ev.Signaled = true;
             }
 
+            if (Status != NTSTATUS.STATUS_PENDING)
+                Instance.WinHelper.QueueFileCompletion(Instance, File, Instance.WinHelper.GetArg(3), Status, Information);
+
             return Status;
         }
 

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtDeviceIoControlFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtDeviceIoControlFile.cs
@@ -13,7 +13,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             ulong EventHandle = Instance.WinHelper.GetArg(1);
 
             // ulong ApcRoutine = Instance.WinHelper.GetArg(2); // not used for now
-            // ulong ApcContext = Instance.WinHelper.GetArg(3); // not used for now
+            ulong ApcContext = Instance.WinHelper.GetArg(3);
             ulong IoStatusBlockPtr = Instance.WinHelper.GetArg(4);
             uint IoControlCode = (uint)Instance.WinHelper.GetArg(5);
             ulong InputBufferPtr = Instance.WinHelper.GetArg(6);
@@ -112,7 +112,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             }
 
             if (Status != NTSTATUS.STATUS_PENDING)
-                Instance.WinHelper.QueueFileCompletion(Instance, File, Instance.WinHelper.GetArg(3), Status, Information);
+                Instance.WinHelper.QueueFileCompletion(Instance, File, ApcContext, Status, Information);
 
             return Status;
         }

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtSetInformationFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtSetInformationFile.cs
@@ -38,13 +38,17 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return NTSTATUS.STATUS_INVALID_HANDLE;
             }
 
+            FILE_INFORMATION_CLASS InfoClass = (FILE_INFORMATION_CLASS)FileInformationClass;
+
+            if (InfoClass == FILE_INFORMATION_CLASS.FileCompletionInformation)
+                return HandleFileCompletionInformation(Instance, FileObj, IoStatusBlock, FileInformation, Length);
+
             if (FileObj.Device)
             {
                 Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlock, NTSTATUS.STATUS_INVALID_DEVICE_REQUEST, 0);
                 return NTSTATUS.STATUS_INVALID_DEVICE_REQUEST;
             }
 
-            FILE_INFORMATION_CLASS InfoClass = (FILE_INFORMATION_CLASS)FileInformationClass;
             switch (InfoClass)
             {
                 case FILE_INFORMATION_CLASS.FileBasicInformation:
@@ -70,6 +74,31 @@ namespace Brovan.Core.Emulation.OS.Windows
                     Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlock, NTSTATUS.STATUS_INVALID_INFO_CLASS, 0);
                     return NTSTATUS.STATUS_INVALID_INFO_CLASS;
             }
+        }
+
+        private static NTSTATUS HandleFileCompletionInformation(BinaryEmulator Instance, WinFile FileObj, ulong IoStatusBlock, ulong FileInformation, uint Length)
+        {
+            uint PointerSize = (uint)Instance.WinHelper.PointerSize;
+            if (Length < PointerSize * 2)
+            {
+                Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlock, NTSTATUS.STATUS_INFO_LENGTH_MISMATCH, 0);
+                return NTSTATUS.STATUS_INFO_LENGTH_MISMATCH;
+            }
+
+            ulong Port = Instance.WinHelper.ReadPointer(FileInformation);
+            ulong Key = Instance.WinHelper.ReadPointer(FileInformation + PointerSize);
+
+            if (Instance.WinHelper.HandleManager.GetObjectByHandle<WinIoCompletion>(Port) == null)
+            {
+                Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlock, NTSTATUS.STATUS_INVALID_HANDLE, 0);
+                return NTSTATUS.STATUS_INVALID_HANDLE;
+            }
+
+            FileObj.CompletionHandle = Port;
+            FileObj.CompletionKey = Key;
+
+            Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlock, NTSTATUS.STATUS_SUCCESS, 0);
+            return NTSTATUS.STATUS_SUCCESS;
         }
 
         private static NTSTATUS HandleFileBasicInformation(BinaryEmulator Instance, ulong FileHandle, WinFile FileObj, ulong IoStatusBlock, ulong FileInformation, uint Length)

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtRemoveIoCompletion.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtRemoveIoCompletion.cs
@@ -46,7 +46,7 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Completion.Entries.Count > 0)
             {
                 WinIoCompletionEntry Entry = Completion.Entries.Dequeue();
-                ReleaseWaitPacket(Instance, Entry);
+                Instance.ReleaseWaitCompletionPacket(Entry);
 
                 if (Thread.WaitActive)
                     Instance.WinHelper.ClearWaitState(Thread);
@@ -80,6 +80,12 @@ namespace Brovan.Core.Emulation.OS.Windows
                 State.WaitResumeRIP = Instance.WinHelper.GetSyscallRip(Thread, false);
                 State.WaitReturnRIP = State.WaitResumeRIP + 2;
                 State.WaitAlertable = false;
+                State.IoCompletionWaitActive = true;
+                State.IoCompletionHandle = IoCompletionHandle;
+                State.IoCompletionKeyContextPtr = KeyContextPtr;
+                State.IoCompletionApcContextPtr = ApcContextPtr;
+                State.IoCompletionIoStatusBlockPtr = IoStatusBlockPtr;
+                State.IoCompletionReservedEntry = null;
             }
 
             Thread.State = EmulatedThreadState.Waiting;
@@ -87,19 +93,6 @@ namespace Brovan.Core.Emulation.OS.Windows
             Instance._emulator.WriteRegister(Instance.IPRegister, State.WaitResumeRIP);
             Instance._emulator.StopEmulation();
             return NTSTATUS.STATUS_PENDING;
-        }
-
-        private static void ReleaseWaitPacket(BinaryEmulator Instance, WinIoCompletionEntry Entry)
-        {
-            if (Entry.WaitCompletionPacketHandle == 0)
-                return;
-
-            WinWaitCompletionPacket Packet = Instance.WinHelper.HandleManager.GetObjectByHandle<WinWaitCompletionPacket>(Entry.WaitCompletionPacketHandle);
-            if (Packet == null)
-                return;
-
-            Packet.Associated = false;
-            Packet.QueuedCompletion = false;
         }
     }
 }

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtRemoveIoCompletion.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtRemoveIoCompletion.cs
@@ -1,0 +1,105 @@
+using static Brovan.Core.Helpers.BinaryHelpers;
+
+namespace Brovan.Core.Emulation.OS.Windows
+{
+    internal class NtRemoveIoCompletion : IWinSyscall
+    {
+        public NTSTATUS Handle(BinaryEmulator Instance)
+        {
+
+            ulong IoCompletionHandle = Instance.WinHelper.GetArg(0);
+            ulong KeyContextPtr = Instance.WinHelper.GetArg(1);
+            ulong ApcContextPtr = Instance.WinHelper.GetArg(2);
+            ulong IoStatusBlockPtr = Instance.WinHelper.GetArg(3);
+            ulong TimeoutPtr = Instance.WinHelper.GetArg(4);
+
+            EmulatedThread Thread = Instance.CurrentThread;
+            if (Thread == null)
+                return NTSTATUS.STATUS_UNSUCCESSFUL;
+
+            uint PointerSize = (uint)Instance.WinHelper.PointerSize;
+            if (KeyContextPtr == 0 || ApcContextPtr == 0 || IoStatusBlockPtr == 0)
+                return NTSTATUS.STATUS_INVALID_PARAMETER;
+
+            if (!Instance.IsRegionMapped(KeyContextPtr, PointerSize)
+                || !Instance.IsRegionMapped(ApcContextPtr, PointerSize)
+                || !Instance.IsRegionMapped(IoStatusBlockPtr, PointerSize * 2))
+                return NTSTATUS.STATUS_ACCESS_VIOLATION;
+
+            WinIoCompletion Completion = Instance.WinHelper.HandleManager.GetObjectByHandle<WinIoCompletion>(IoCompletionHandle);
+            if (Completion == null)
+                return NTSTATUS.STATUS_INVALID_HANDLE;
+
+            WindowsThreadState State = WinEmulatedThread.GetState(Thread);
+            if (State.WaitCompleted)
+            {
+                NTSTATUS Completed = State.WaitStatus;
+                State.WaitCompleted = false;
+                State.WaitStatus = NTSTATUS.STATUS_SUCCESS;
+
+                if (Completed == NTSTATUS.STATUS_TIMEOUT)
+                    return Completed;
+            }
+
+            Instance.MaterializeSignaledWaitPackets(IoCompletionHandle);
+
+            if (Completion.Entries.Count > 0)
+            {
+                WinIoCompletionEntry Entry = Completion.Entries.Dequeue();
+                ReleaseWaitPacket(Instance, Entry);
+
+                if (Thread.WaitActive)
+                    Instance.WinHelper.ClearWaitState(Thread);
+
+                Instance.WinHelper.WritePointer(KeyContextPtr, Entry.KeyContext);
+                Instance.WinHelper.WritePointer(ApcContextPtr, Entry.ApcContext);
+                Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlockPtr, Entry.IoStatus, Entry.IoStatusInformation);
+                return NTSTATUS.STATUS_SUCCESS;
+            }
+
+            if (Thread.WaitActive)
+            {
+                if (Instance.IsEmulatedDeadlineExpired(Thread.WaitDeadline))
+                {
+                    Instance.WinHelper.ClearWaitState(Thread);
+                    return NTSTATUS.STATUS_TIMEOUT;
+                }
+            }
+            else
+            {
+                long NewDeadline = Instance.WinHelper.ParseRelativeDeadlineMs(TimeoutPtr);
+                if (NewDeadline == Instance.EmulatedTickCount64)
+                    return NTSTATUS.STATUS_TIMEOUT;
+
+                Thread.WaitActive = true;
+                Thread.WaitHandles = new List<ulong> { IoCompletionHandle };
+                Thread.WaitAll = true;
+                Thread.WaitDeadline = NewDeadline;
+                State.WaitCompleted = false;
+                State.WaitStatus = NTSTATUS.STATUS_PENDING;
+                State.WaitResumeRIP = Instance.WinHelper.GetSyscallRip(Thread, false);
+                State.WaitReturnRIP = State.WaitResumeRIP + 2;
+                State.WaitAlertable = false;
+            }
+
+            Thread.State = EmulatedThreadState.Waiting;
+            State.ApcAlertable = false;
+            Instance._emulator.WriteRegister(Instance.IPRegister, State.WaitResumeRIP);
+            Instance._emulator.StopEmulation();
+            return NTSTATUS.STATUS_PENDING;
+        }
+
+        private static void ReleaseWaitPacket(BinaryEmulator Instance, WinIoCompletionEntry Entry)
+        {
+            if (Entry.WaitCompletionPacketHandle == 0)
+                return;
+
+            WinWaitCompletionPacket Packet = Instance.WinHelper.HandleManager.GetObjectByHandle<WinWaitCompletionPacket>(Entry.WaitCompletionPacketHandle);
+            if (Packet == null)
+                return;
+
+            Packet.Associated = false;
+            Packet.QueuedCompletion = false;
+        }
+    }
+}

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtSetIoCompletion.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtSetIoCompletion.cs
@@ -1,0 +1,34 @@
+using static Brovan.Core.Helpers.BinaryHelpers;
+
+namespace Brovan.Core.Emulation.OS.Windows
+{
+    internal class NtSetIoCompletion : IWinSyscall
+    {
+        public NTSTATUS Handle(BinaryEmulator Instance)
+        {
+
+            ulong IoCompletionHandle = Instance.WinHelper.GetArg(0);
+            ulong KeyContext = Instance.WinHelper.GetArg(1);
+            ulong ApcContext = Instance.WinHelper.GetArg(2);
+            NTSTATUS IoStatus = (NTSTATUS)(int)(uint)Instance.WinHelper.GetArg(3);
+            ulong IoStatusInformation = Instance.WinHelper.GetArg(4);
+
+            WinIoCompletion Completion = Instance.WinHelper.HandleManager.GetObjectByHandle<WinIoCompletion>(IoCompletionHandle);
+            if (Completion == null)
+                return NTSTATUS.STATUS_INVALID_HANDLE;
+
+            Completion.Entries.Enqueue(new WinIoCompletionEntry
+            {
+                KeyContext = KeyContext,
+                ApcContext = ApcContext,
+                IoStatus = IoStatus,
+                IoStatusInformation = IoStatusInformation
+            });
+
+            if (Instance.WakeWorkerFactoryWaitersForObject(IoCompletionHandle))
+                Instance._emulator.StopEmulation();
+
+            return NTSTATUS.STATUS_SUCCESS;
+        }
+    }
+}

--- a/Brovan/Core/Emulation/OS/Windows/WinHelperConstants.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinHelperConstants.cs
@@ -311,6 +311,7 @@ namespace Brovan.Core.Emulation.OS.Windows
         FileAllInformation = 18,
         FileAllocationInformation = 19,
         FileEndOfFileInformation = 20,
+        FileCompletionInformation = 30,
         FileNetworkOpenInformation = 34,
         FileAttributeTagInformation = 35,
         FileNormalizedNameInformation = 48,
@@ -1156,6 +1157,13 @@ namespace Brovan.Core.Emulation.OS.Windows
         public long BasicChangeTime;
         public string OpenId = Guid.NewGuid().ToString("N");
         public List<WinLockFile> Locks = new List<WinLockFile>();
+
+        /// <summary>
+        /// Completion port bound with FileCompletionInformation. Every finished request on this handle queues a
+        /// packet carrying <see cref="CompletionKey"/>, which is how overlapped I/O is collected.
+        /// </summary>
+        public ulong CompletionHandle;
+        public ulong CompletionKey;
 
         public WinDeviceDelegate Handler;
 

--- a/Brovan/Core/Emulation/OS/Windows/WinSyscallsHelper.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinSyscallsHelper.cs
@@ -209,6 +209,12 @@ namespace Brovan.Core.Emulation.OS.Windows
             State.MsgWaitActive = false;
             State.MsgWaitMask = 0;
             State.GetMessageWaitActive = false;
+            State.IoCompletionWaitActive = false;
+            State.IoCompletionHandle = 0;
+            State.IoCompletionKeyContextPtr = 0;
+            State.IoCompletionApcContextPtr = 0;
+            State.IoCompletionIoStatusBlockPtr = 0;
+            State.IoCompletionReservedEntry = null;
 
             if (ClearAlertByThreadId)
             {

--- a/Brovan/Core/Emulation/OS/Windows/WinSyscallsHelper.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinSyscallsHelper.cs
@@ -260,6 +260,31 @@ namespace Brovan.Core.Emulation.OS.Windows
             WriteIoStatusBlock(Emulator, IoStatusBlockPtr, Status, Information);
         }
 
+        /// <summary>
+        /// Queues the completion packet a finished request owes its handle's completion port. Requests that carry
+        /// no APC context are synchronous waits rather than overlapped I/O and queue nothing.
+        /// </summary>
+        public void QueueFileCompletion(BinaryEmulator Instance, WinFile File, ulong ApcContext, NTSTATUS Status, ulong Information)
+        {
+            if (File == null || File.CompletionHandle == 0 || ApcContext == 0)
+                return;
+
+            WinIoCompletion Completion = HandleManager.GetObjectByHandle<WinIoCompletion>(File.CompletionHandle);
+            if (Completion == null)
+                return;
+
+            Completion.Entries.Enqueue(new WinIoCompletionEntry
+            {
+                KeyContext = File.CompletionKey,
+                ApcContext = ApcContext,
+                IoStatus = Status,
+                IoStatusInformation = Information
+            });
+
+            if (Instance.WakeWorkerFactoryWaitersForObject(File.CompletionHandle))
+                Instance._emulator.StopEmulation();
+        }
+
         public void WriteIoStatusBlock(BinaryEmulator Instance, ulong IoStatusBlockPtr, NTSTATUS Status, ulong Information)
         {
             if (PointerSize == 8)

--- a/Brovan/Core/Emulation/OS/Windows/WinThreading.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinThreading.cs
@@ -36,6 +36,12 @@ namespace Brovan.Core.Emulation.OS.Windows
         public ulong WorkerFactoryPacketsReturned { get; set; }
         public uint WorkerFactoryMaxPackets { get; set; }
         public List<WinIoCompletionEntry> WorkerFactoryReservedEntries { get; set; } = new();
+        public bool IoCompletionWaitActive { get; set; }
+        public ulong IoCompletionHandle { get; set; }
+        public ulong IoCompletionKeyContextPtr { get; set; }
+        public ulong IoCompletionApcContextPtr { get; set; }
+        public ulong IoCompletionIoStatusBlockPtr { get; set; }
+        public WinIoCompletionEntry IoCompletionReservedEntry { get; set; }
         public ulong WaitResumeRIP { get; set; }
         public ulong WaitReturnRIP { get; set; }
         public bool WaitAlertable { get; set; }

--- a/Brovan/EmulationMenu/Helpers.cs
+++ b/Brovan/EmulationMenu/Helpers.cs
@@ -2519,6 +2519,9 @@ namespace Brovan
                 if (WindowsState.WorkerFactoryWaitActive)
                     return $"worker-factory 0x{WindowsState.WorkerFactoryHandle:X}";
 
+                if (WindowsState.IoCompletionWaitActive)
+                    return $"io-completion 0x{WindowsState.IoCompletionHandle:X}";
+
                 if (WindowsState.AlertByThreadIdWaitActive)
                     return $"alertbythreadid 0x{WindowsState.AlertByThreadIdAddress:X}";
 


### PR DESCRIPTION
Implement emulation for `NtSetIoCompletion` and `NtRemoveIoCompletion`, including wait-state handling, timeout behavior, and completion packet release. Wire file handles to completion ports via `FileCompletionInformation` in `NtSetInformationFile`, store completion key/port on `WinFile`, and enqueue completion packets for completed `NtDeviceIoControlFile` requests. Also update waiter wake-up logic to resume threads waiting on generic handles (including IO completion objects), and improve invalid-memory issue logs with resolved Windows address context and stack module frames.