### PR TITLE
Support multi-threading in hypervisors

### DIFF
--- a/Brovan/Core/Emulation/Backends/IEmulationBackend.cs
+++ b/Brovan/Core/Emulation/Backends/IEmulationBackend.cs
@@ -187,6 +187,8 @@ namespace Brovan.Core.Emulation
         /// </summary>
         bool SupportsThreadResidency => false;
 
+        int ProcessorLimit => 1;
+
         bool TryBindThread(uint threadId) => false;
 
         void UnbindThread(uint threadId)
@@ -204,6 +206,23 @@ namespace Brovan.Core.Emulation
         /// backend has no bounded slice to shorten, in which case the caller has to stop the slice itself.
         /// </summary>
         bool TryLimitSlice(int microseconds) => false;
+
+        /// <summary>
+        /// The lock the caller holds around <see cref="Emulate"/>. A backend releases it only for the time
+        /// the guest runs.
+        /// </summary>
+        void UseRunLock(object runLock)
+        {
+        }
+
+        /// <summary>Ends the slice of the thread's processor, not the thread.</summary>
+        void StopThread(uint threadId)
+        {
+        }
+
+        void StopAllProcessors()
+        {
+        }
 
         /// <summary>
         /// Answers RDTSC inside the backend from the emulator's clock. False when the backend has no such path.

--- a/Brovan/Core/Emulation/Backends/Kvm/KvmBackend.cs
+++ b/Brovan/Core/Emulation/Backends/Kvm/KvmBackend.cs
@@ -111,11 +111,15 @@ namespace Brovan.Core.Emulation
             => Inner.TransferXmmRegisters(values, true);
 
         public bool SupportsThreadResidency => Inner.SupportsThreadResidency;
+        public int ProcessorLimit => Inner.ProcessorLimit;
         public bool TryBindThread(uint threadId) => Inner.TryBindThread(threadId);
         public void UnbindThread(uint threadId) => Inner.UnbindThread(threadId);
         public bool IsThreadResident(uint threadId) => Inner.IsThreadResident(threadId);
         public void SelectThread(uint threadId) => Inner.SelectThread(threadId);
         public bool TryLimitSlice(int microseconds) => Inner.TryLimitSlice(microseconds);
+        public void UseRunLock(object runLock) => Inner.UseRunLock(runLock);
+        public void StopThread(uint threadId) => Inner.StopThread(threadId);
+        public void StopAllProcessors() => Inner.StopAllProcessors();
         public uint ReadRegister32(Registers register)
             => Inner.ReadRegister32(register);
         public uint ReadRegister32(int register)

--- a/Brovan/Core/Emulation/Backends/Whp/WhpBackend.cs
+++ b/Brovan/Core/Emulation/Backends/Whp/WhpBackend.cs
@@ -129,11 +129,15 @@ namespace Brovan.Core.Emulation
             => Inner.TransferXmmRegisters(values, true);
 
         public bool SupportsThreadResidency => Inner.SupportsThreadResidency;
+        public int ProcessorLimit => Inner.ProcessorLimit;
         public bool TryBindThread(uint threadId) => Inner.TryBindThread(threadId);
         public void UnbindThread(uint threadId) => Inner.UnbindThread(threadId);
         public bool IsThreadResident(uint threadId) => Inner.IsThreadResident(threadId);
         public void SelectThread(uint threadId) => Inner.SelectThread(threadId);
         public bool TryLimitSlice(int microseconds) => Inner.TryLimitSlice(microseconds);
+        public void UseRunLock(object runLock) => Inner.UseRunLock(runLock);
+        public void StopThread(uint threadId) => Inner.StopThread(threadId);
+        public void StopAllProcessors() => Inner.StopAllProcessors();
 
         public IntPtr AddCodeHook(ulong begin, ulong end, CodeHookCallback callback)
             => Inner.AddCodeHook(begin, end, callback);

--- a/Brovan/Core/Emulation/BinaryEmulator.cs
+++ b/Brovan/Core/Emulation/BinaryEmulator.cs
@@ -299,6 +299,12 @@ namespace Brovan.Core.Emulation
         /// <summary>Backend implementation to use. Defaults to Unicorn.</summary>
         public EmulationBackendKind BackendKind;
 
+        /// <summary>Runs guest threads on several host threads at once. Hypervisor backends only.</summary>
+        public bool Smp;
+
+        /// <summary>Host threads that run guest code at once. Zero picks a count from the host.</summary>
+        public int SmpWorkers;
+
 #pragma warning disable
         public BinaryEmulatorSettings()
         {
@@ -315,6 +321,7 @@ namespace Brovan.Core.Emulation
             NetworkPolicy = null;
             Debug = false;
             BackendKind = EmulationBackendKind.Unicorn;
+            Smp = true;
 #pragma warning restore
         }
 
@@ -378,7 +385,6 @@ namespace Brovan.Core.Emulation
         private const int GprBatchCount = 18;
         private const int GprBatchCount32 = 10;
         private int[] _gprBatchRegs;
-        private ulong[] _gprBatchScratch;
         internal BinaryEmulatorSettings Settings;
         private InstructionHookCallback Syscall;
         private InstructionHookCallback Privileged;
@@ -438,6 +444,179 @@ namespace Brovan.Core.Emulation
         /// How long the scheduler blocks in one go when no guest thread can run.
         /// </summary>
         private const int IdleWaitSliceMs = 5;
+
+        // Held by every host thread that touches emulator state. A hypervisor backend releases it only for
+        // the time a processor spends in the guest, see IEmulationBackend.UseRunLock.
+        internal readonly object KernelLock = new();
+
+        private bool SmpEnabled;
+        private volatile bool SchedulerExiting;
+        private int IdleWorkers;
+        private int ParkWaiters;
+        private int DispatchedThreads;
+        private int SmpWorkerCount;
+        private ulong _schedulerTotal;
+        private uint _schedulerSlices;
+        private ulong _schedulerPendingInstructions;
+
+        private const int IdleWaitBackstopMs = 50;
+        private const int SweepIntervalMs = 1;
+        private const int SchedulerThreadStackSize = 4 * 1024 * 1024;
+
+        // An idle worker sleeps until a producer or the sweeper pulses it. The timeout is only a backstop
+        // against a lost pulse.
+        private void IdleWait(int Milliseconds)
+        {
+            if (!SmpEnabled)
+            {
+                Thread.Sleep(Milliseconds);
+                return;
+            }
+
+            IdleWorkers++;
+            Monitor.Wait(KernelLock, IdleWaitBackstopMs);
+            IdleWorkers--;
+        }
+
+        // A dispatched thread is invisible to every scan, so a worker leaving its slice by any route, an
+        // escaping exception included, has to give it back.
+        private void ReleaseDispatch(SchedulerWorker Worker)
+        {
+            EmulatedThread Dispatched = Worker.DispatchedThread;
+            if (Dispatched == null)
+                return;
+
+            Worker.DispatchedThread = null;
+            Dispatched.HostWorker = -1;
+            DispatchedThreads--;
+            if (ParkWaiters != 0)
+                Monitor.PulseAll(KernelLock);
+        }
+
+        private void WakeIdleWorker()
+        {
+            if (ParkWaiters != 0)
+                Monitor.PulseAll(KernelLock);
+            else
+                Monitor.Pulse(KernelLock);
+        }
+
+        // Timed wakes have no producer, so one thread wakes an idle worker at the idle cadence.
+        private void SweepLoop()
+        {
+            while (!SchedulerExiting)
+            {
+                Thread.Sleep(SweepIntervalMs);
+                lock (KernelLock)
+                {
+                    if (IdleWorkers != 0)
+                        WakeIdleWorker();
+                }
+            }
+        }
+
+        private void SignalSchedulerExit()
+        {
+            SchedulerExiting = true;
+            _emulator.StopAllProcessors();
+            Monitor.PulseAll(KernelLock);
+        }
+
+        private static Thread StartSchedulerThread(string Name, ThreadStart Body)
+        {
+            Thread Started = new Thread(Body, SchedulerThreadStackSize)
+            {
+                IsBackground = true,
+                Name = Name
+            };
+            Started.Start();
+            return Started;
+        }
+
+        private int ResolveSmpWorkerCount()
+        {
+            int Requested = Settings.SmpWorkers > 0 ? Settings.SmpWorkers : Math.Max(1, Environment.ProcessorCount - 1);
+
+            // One processor stays free, so a thread past the limit can always evict a parked one.
+            int Limit = _emulator.ProcessorLimit - 1;
+            return Math.Max(1, Math.Min(Requested, Limit));
+        }
+
+        // NT answers a context request on a running thread only once it reaches a safe point. False means it
+        // never reached one, so the saved context is not the one it runs on.
+        internal bool WaitUntilParked(EmulatedThread Thread)
+        {
+            if (!SmpEnabled || Thread == null || Thread.HostWorker == -1 || ReferenceEquals(Thread, CurrentThread))
+                return true;
+
+            _emulator.StopThread(Thread.ThreadId);
+
+            EmulatedThread Self = CurrentThread;
+            if (Self != null)
+            {
+                Self.ParkTarget = Thread;
+                Self.ParkWaiting = true;
+            }
+            ParkWaiters++;
+            try
+            {
+                long Deadline = System.Diagnostics.Stopwatch.GetTimestamp() + System.Diagnostics.Stopwatch.Frequency / 4;
+                while (Thread.HostWorker != -1 && !SchedulerExiting)
+                {
+                    // Two threads inspecting each other are both inside a handler, so neither parks.
+                    if (Self != null && Thread.ParkWaiting && ReferenceEquals(Thread.ParkTarget, Self))
+                        return false;
+                    if (System.Diagnostics.Stopwatch.GetTimestamp() >= Deadline)
+                        return false;
+
+                    Monitor.Wait(KernelLock, 1);
+                }
+
+                return Thread.HostWorker == -1;
+            }
+            finally
+            {
+                ParkWaiters--;
+                if (Self != null)
+                {
+                    Self.ParkWaiting = false;
+                    Self.ParkTarget = null;
+                }
+            }
+        }
+
+        // The console thread's view of the guest follows the thread it last ran once the workers are gone.
+        private void ReselectCurrentThread()
+        {
+            SchedulerWorker Main = _mainWorker;
+            if (Main.CurrentThreadId == -1 && Main.LastThreadId != -1)
+                Main.CurrentThreadId = Main.LastThreadId;
+
+            EmulatedThread Current = CurrentThread;
+            if (Current == null || Current.Context == null)
+                return;
+
+            if (!_emulator.IsThreadResident(Current.ThreadId) && Current.State != EmulatedThreadState.Terminated && BindThreadProcessor(Current))
+            {
+                _emulator.SelectThread(Current.ThreadId);
+                LoadContext(Current, true);
+                CurrentContextSaved = true;
+                return;
+            }
+
+            _emulator.SelectThread(Current.ThreadId);
+        }
+
+        // A producer completes the waiters it woke before its own slice resumes. The thread it runs on is
+        // dispatched, so the scan skips it and its worker checks it after the slice.
+        private void ScanWakeupsAfterCallback(long EpochBeforeCallback)
+        {
+            if (!SmpEnabled || MlfqLevels == 0 || WakeSignal.Current == EpochBeforeCallback
+                || WakeSignal.Current == LastScannedWakeEpoch)
+                return;
+
+            UpdateMlfqWakeups(MlfqReadyQueues, MlfqQueuedThreads, MlfqLevels, MlfqSchedulerTick);
+        }
 
         private const ulong TscCyclesPerMillisecond = 3_000_000UL;
 
@@ -569,14 +748,15 @@ namespace Brovan.Core.Emulation
 
         private bool StartSuspendedReleased;
         internal readonly List<int> ThreadOrder = new();
-        internal int CurrentThreadId = -1;
         internal int NextThreadId = 1;
-        private bool SchedulerRefreshRequested;
-        internal bool EscapeScheduler;
+        internal volatile bool EscapeScheduler;
         private int TerminationRequested;
 
-        // Threads keeps terminated entries so thread-id lookups stay valid, so it grows with every thread the guest
-        // has ever created. ThreadOrder is the live set.
+        internal int CurrentThreadId { get => Worker.CurrentThreadId; set => Worker.CurrentThreadId = value; }
+        private bool SchedulerRefreshRequested { get => Worker.RefreshRequested; set => Worker.RefreshRequested = value; }
+
+        // Threads keeps a terminated entry while something still refers to it, so a thread-id lookup made
+        // with a handle open stays valid. ThreadOrder is the live set.
         internal LiveThreadCollection LiveThreads => new LiveThreadCollection(this);
 
         internal readonly struct LiveThreadCollection
@@ -622,24 +802,66 @@ namespace Brovan.Core.Emulation
             }
         }
 
-        private EmulatedThread _currentThreadCache;
-
-        private bool _currentContextSaved;
-
         // Never lowered. Windows releases the request when the process exits.
         private static bool _hostTimerPeriodRaised;
+
+        private sealed class SchedulerWorker
+        {
+            public readonly BinaryEmulator Owner;
+            public readonly int Index;
+            public int CurrentThreadId = -1;
+            public int LastThreadId = -1;
+            public EmulatedThread CurrentThreadCache;
+            public bool ContextSaved;
+            public bool RefreshRequested;
+            public bool SuppressStatusWrite;
+            public bool WakeupScanRequired;
+            public EmulatedThread DispatchedThread;
+            public ulong[] GprScratch;
+
+            public SchedulerWorker(BinaryEmulator Owner, int Index)
+            {
+                this.Owner = Owner;
+                this.Index = Index;
+            }
+        }
+
+        [ThreadStatic]
+        private static SchedulerWorker t_worker;
+        private SchedulerWorker _mainWorker;
+
+        private SchedulerWorker Worker
+        {
+            get
+            {
+                SchedulerWorker Bound = t_worker;
+                return Bound != null && ReferenceEquals(Bound.Owner, this) ? Bound : _mainWorker;
+            }
+        }
+
+        private void BindMainWorker()
+        {
+            _mainWorker = new SchedulerWorker(this, 0);
+            t_worker = _mainWorker;
+        }
+
+        private EmulatedThread CurrentThreadCache { get => Worker.CurrentThreadCache; set => Worker.CurrentThreadCache = value; }
+
+        private bool CurrentContextSaved { get => Worker.ContextSaved; set => Worker.ContextSaved = value; }
 
         internal EmulatedThread CurrentThread
         {
             get
             {
-                int tid = CurrentThreadId;
+                SchedulerWorker W = Worker;
+                int tid = W.CurrentThreadId;
                 if (tid == -1) return null;
-                if (_currentThreadCache != null && (int)_currentThreadCache.ThreadId == tid)
-                    return _currentThreadCache;
+                EmulatedThread Cached = W.CurrentThreadCache;
+                if (Cached != null && (int)Cached.ThreadId == tid)
+                    return Cached;
                 if (Threads.TryGetValue((uint)tid, out EmulatedThread t))
-                { _currentThreadCache = t; return t; }
-                _currentThreadCache = null;
+                { W.CurrentThreadCache = t; return t; }
+                W.CurrentThreadCache = null;
                 return null;
             }
         }
@@ -667,6 +889,7 @@ namespace Brovan.Core.Emulation
             if (Binary.Architecture == BinaryArchitecture.Unknown)
                 throw new BadImageFormatException("Unsupported binary architecture.");
 
+            BindMainWorker();
             _binary = Binary;
             BackendArch = Arch.X86;
             BackendMode = Binary.Architecture == BinaryArchitecture.x64 ? Mode.MODE_64 : Mode.MODE_32;
@@ -709,6 +932,7 @@ namespace Brovan.Core.Emulation
             if (Data == null || Data.Length == 0)
                 throw new NullReferenceException(nameof(Data));
 
+            BindMainWorker();
             _binary = Binary ?? new BinaryFile(Data, true);
             BackendArch = arch;
             BackendMode = mode;
@@ -1561,7 +1785,7 @@ namespace Brovan.Core.Emulation
                 return false;
             }
 
-            if (_emulator.UnmapMemory(Address, Region.Size))
+            if (_emulator.UnmapMemory(Address, AlignToPageSize(Region.Size)))
             {
                 RemoveMemoryRegion(Region);
                 _freedmemory.Add(Region);
@@ -1690,6 +1914,7 @@ namespace Brovan.Core.Emulation
         {
             SchedulerRefreshRequested = true;
             TriggerDebugMessage(() => $"cpu: interrupt 0x{interrupt_number:X} at 0x{ReadRegister(IPRegister):X}");
+            long EpochBeforeCallback = WakeSignal.Current;
             try
             {
                 // An unhandled vector leaves IP on the faulting instruction, which re-faults forever.
@@ -1700,6 +1925,8 @@ namespace Brovan.Core.Emulation
             {
                 Utils.LogError($"[GuestInterrupt] Error: {ex.Message}");
             }
+
+            ScanWakeupsAfterCallback(EpochBeforeCallback);
         }
 
         /// <summary>
@@ -1910,10 +2137,19 @@ namespace Brovan.Core.Emulation
             return Counter > ulong.MaxValue / TscTicksPerQpcTick ? ulong.MaxValue : Counter * TscTicksPerQpcTick;
         }
 
+        // A backend with a real TSC answers from it, so a thread's clock never steps into another domain.
+        private ulong ReadGuestTimestampCounter()
+        {
+            if (!_emulator.TimestampCounterIsEmulated && _emulator.TryReadTimestampCounter(out ulong Counter) && Counter != 0)
+                return Counter;
+
+            return GetEmulatedTimestampCounter();
+        }
+
         private bool RDTSC_Handler()
         {
             ulong IP = ReadRegister(IPRegister);
-            ulong ticks = GetEmulatedTimestampCounter();
+            ulong ticks = ReadGuestTimestampCounter();
 
             if (_binary.Architecture == BinaryArchitecture.x64)
             {
@@ -1935,7 +2171,7 @@ namespace Brovan.Core.Emulation
         private bool RDTSCP_Handler()
         {
             ulong IP = ReadRegister(IPRegister);
-            ulong ticks = GetEmulatedTimestampCounter();
+            ulong ticks = ReadGuestTimestampCounter();
 
             if (_binary.Architecture == BinaryArchitecture.x64)
             {
@@ -2053,7 +2289,7 @@ namespace Brovan.Core.Emulation
         {
             if (c == null) return false;
             int[] Regs = GetGprBatchRegs();
-            ulong[] Vals = _gprBatchScratch ??= new ulong[GprBatchCount];
+            ulong[] Vals = Worker.GprScratch ??= new ulong[GprBatchCount];
             if (!_emulator.ReadRegisterBatch(Regs, Vals, Regs.Length))
                 return false;
             c.RAX = Vals[0]; c.RBX = Vals[1]; c.RCX = Vals[2]; c.RDX = Vals[3];
@@ -2073,7 +2309,7 @@ namespace Brovan.Core.Emulation
         {
             if (c == null) return;
             int[] Regs = GetGprBatchRegs();
-            ulong[] Vals = _gprBatchScratch ??= new ulong[GprBatchCount];
+            ulong[] Vals = Worker.GprScratch ??= new ulong[GprBatchCount];
             Vals[0] = c.RAX; Vals[1] = c.RBX; Vals[2] = c.RCX; Vals[3] = c.RDX;
             Vals[4] = c.RSI; Vals[5] = c.RDI; Vals[6] = c.RBP; Vals[7] = c.RSP;
             if (Regs.Length == GprBatchCount32)
@@ -2118,22 +2354,17 @@ namespace Brovan.Core.Emulation
             Guest.OnThreadContextLoaded(this, t);
         }
 
-        private void SwitchToThread(int ThreadId)
+        private void SwitchToThread(int ThreadId, bool BoundThisSwitch = false)
         {
             if (!Threads.TryGetValue((uint)ThreadId, out EmulatedThread next))
                 return;
-            EmulatedThread cur = _currentThreadCache;
-            if (cur != null)
-            {
-                if (!_currentContextSaved)
-                    SaveContext(cur);
-                if (cur.State == EmulatedThreadState.Terminated)
-                    ReleaseThreadProcessor(cur);
-            }
-            _currentContextSaved = false;
+            EmulatedThread cur = CurrentThreadCache;
+            if (!SmpEnabled && cur != null && !CurrentContextSaved && cur.State != EmulatedThreadState.Terminated)
+                SaveContext(cur);
+            CurrentContextSaved = false;
             CurrentThreadId = ThreadId;
-            _currentThreadCache = next;
-            bool FirstResidentLoad = !_emulator.IsThreadResident(next.ThreadId) && BindThreadProcessor(next);
+            CurrentThreadCache = next;
+            bool FirstResidentLoad = BoundThisSwitch || (!_emulator.IsThreadResident(next.ThreadId) && BindThreadProcessor(next));
             _emulator.SelectThread(next.ThreadId);
             LoadContext(next, FirstResidentLoad || !_emulator.IsThreadResident(next.ThreadId));
         }
@@ -2149,7 +2380,7 @@ namespace Brovan.Core.Emulation
                 return true;
 
             foreach (EmulatedThread Other in Threads.Values)
-                if (Other.State == EmulatedThreadState.Terminated)
+                if (Other.State == EmulatedThreadState.Terminated && Other.HostWorker == -1)
                     _emulator.UnbindThread(Other.ThreadId);
 
             if (_emulator.TryBindThread(Thread.ThreadId))
@@ -2170,7 +2401,7 @@ namespace Brovan.Core.Emulation
             {
                 if (!Threads.TryGetValue((uint)ThreadOrder[i], out EmulatedThread Candidate))
                     continue;
-                if (ReferenceEquals(Candidate, Thread) || Candidate.Context == null || !_emulator.IsThreadResident(Candidate.ThreadId))
+                if (ReferenceEquals(Candidate, Thread) || Candidate.HostWorker != -1 || Candidate.Context == null || !_emulator.IsThreadResident(Candidate.ThreadId))
                     continue;
                 if (Victim == null || Candidate.LastRunTick < Victim.LastRunTick)
                     Victim = Candidate;
@@ -2187,7 +2418,7 @@ namespace Brovan.Core.Emulation
             return true;
         }
 
-        private void ReleaseThreadProcessor(EmulatedThread Thread)
+        internal void ReleaseThreadProcessor(EmulatedThread Thread)
         {
             if (!_emulator.IsThreadResident(Thread.ThreadId))
                 return;
@@ -2224,10 +2455,10 @@ namespace Brovan.Core.Emulation
             if (!Threads.TryGetValue(ThreadId, out EmulatedThread Thread) || Thread == null || Thread.Context == null)
                 return false;
 
-            if (Thread.State == EmulatedThreadState.Terminated)
+            if (Thread.State == EmulatedThreadState.Terminated || Thread.HostWorker != -1)
                 return false;
 
-            _currentContextSaved = false;
+            CurrentContextSaved = false;
             SwitchToThread((int)ThreadId);
             return CurrentThreadId == (int)ThreadId;
         }
@@ -2293,6 +2524,8 @@ namespace Brovan.Core.Emulation
 
             if (CurrentThreadId == (int)ThreadId && Thread.Context != null)
                 SaveContext(Thread);
+            else
+                WaitUntilParked(Thread);
 
             Thread.ExitCode = ExitCode;
             Thread.WaitActive = false;
@@ -2331,6 +2564,10 @@ namespace Brovan.Core.Emulation
                 if (!IsX86Guest)
                     _emulator.WriteRegister(IPRegister, _emulator.ReadRegister(IPRegister) + 2);
                 _emulator.StopEmulation();
+            }
+            else
+            {
+                _emulator.StopThread(Thread.ThreadId);
             }
         }
 
@@ -2387,7 +2624,7 @@ namespace Brovan.Core.Emulation
 
         private bool IsMlfqRunnableThread(EmulatedThread Thread)
         {
-            if (Thread == null)
+            if (Thread == null || Thread.HostWorker != -1)
                 return false;
 
             if (Thread.State == EmulatedThreadState.Terminated)
@@ -2427,7 +2664,7 @@ namespace Brovan.Core.Emulation
         {
             bool Changed = false;
 
-            if (Thread == null)
+            if (Thread == null || Thread.HostWorker != -1)
                 return false;
 
             if (Thread.State == EmulatedThreadState.Suspended && Thread.SuspendCount == 0)
@@ -2573,6 +2810,11 @@ namespace Brovan.Core.Emulation
             t.LastReadyTick = SchedulerTick;
 
             ReadyQueues[Level].Enqueue(Tid);
+
+            // Any worker still awake reaches the queue within a slice, and a pulse for the same thread costs
+            // more in lock contention than the wait it saves. Only a fully parked guest has nobody to reach it.
+            if (IdleWorkers != 0 && IdleWorkers == SmpWorkerCount)
+                WakeIdleWorker();
         }
 
         private void EnsureMlfqRunnableThreadsEnqueued(Queue<int>[] ReadyQueues, HashSet<int> InQueue, int Levels, long SchedulerTick)
@@ -2733,16 +2975,8 @@ namespace Brovan.Core.Emulation
             HashSet<int> InQueue = MlfqQueuedThreads;
             InQueue.Clear();
 
-            ulong Total = 0;
-            uint Slices = 0;
-            long SchedulerTick = 0;
-            ulong PendingSchedulerInstructions = 0;
-            const ulong SchedulerRescanInstructions = 1_000_000;
-            const long FullWakeupScanIntervalMs = 1;
-            const uint FullWakeupScanSliceLimit = 1024;
             long AgingThresholdBudget = AgingThresholdSlices <= 0 ? 0 : AgingThresholdSlices;
             int KnownThreadOrderCount = ThreadOrder.Count;
-            bool WakeupScanRequired = true;
 
             if (Debug)
                 TriggerDebugMessage($"scheduler: start threads={ThreadOrder.Count} levels={Levels} baseQuantum={BaseQuantumInstructions} maxInstructions={MaxTotalInstructions} maxSlices={MaxSlices}");
@@ -2755,19 +2989,111 @@ namespace Brovan.Core.Emulation
                     SuspendThread(Thread, out _, false);
             }
 
-            RebuildMlfqReadyQueues(ReadyQueues, InQueue, Levels, SchedulerTick, AgingThresholdBudget, 1);
+            RebuildMlfqReadyQueues(ReadyQueues, InQueue, Levels, 0, AgingThresholdBudget, 1);
             SchedulerRefreshRequested = false;
 
             // A register written from outside the loop is only captured by a fresh save.
-            _currentContextSaved = false;
+            CurrentContextSaved = false;
 
             if (!_hostTimerPeriodRaised)
                 _hostTimerPeriodRaised = GeneralHelper.BeginHostTimerPeriod();
 
+            _schedulerTotal = 0;
+            _schedulerSlices = 0;
+            _schedulerPendingInstructions = 0;
+            MlfqSchedulerTick = 0;
+
+            SchedulerExiting = false;
+            IdleWorkers = 0;
+            ParkWaiters = 0;
+            DispatchedThreads = 0;
+            foreach (EmulatedThread Dispatched in Threads.Values)
+                Dispatched.HostWorker = -1;
+
+            SmpEnabled = Settings.Smp && _emulator.SupportsThreadResidency;
+            if (!SmpEnabled)
+            {
+                try
+                {
+                    return RunSchedulerLoop(ReadyQueues, InQueue, Levels, MaxTotalInstructions, MaxSlices, AgingThresholdSlices, AgingThresholdBudget, KnownThreadOrderCount);
+                }
+                finally
+                {
+                    ReleaseDispatch(_mainWorker);
+                }
+            }
+
+            // Another worker may dispatch the thread before this one switches again, so the context loaded
+            // before the run is captured here.
+            EmulatedThread Loaded = CurrentThread;
+            if (Loaded != null && !CurrentContextSaved && Loaded.State != EmulatedThreadState.Terminated)
+                SaveContext(Loaded);
+            CurrentContextSaved = true;
+
+            _emulator.UseRunLock(KernelLock);
+
+            int WorkerCount = ResolveSmpWorkerCount();
+            SmpWorkerCount = WorkerCount;
+            Thread[] Helpers = new Thread[WorkerCount];
+            Helpers[0] = StartSchedulerThread("BrovanSchedulerSweep", SweepLoop);
+            for (int i = 1; i < WorkerCount; i++)
+            {
+                SchedulerWorker Extra = new SchedulerWorker(this, i);
+                Helpers[i] = StartSchedulerThread($"BrovanScheduler-{i}",
+                    () => RunSchedulerWorker(Extra, ReadyQueues, InQueue, Levels, MaxTotalInstructions, MaxSlices, AgingThresholdSlices, AgingThresholdBudget));
+            }
+
+            try
+            {
+                return RunSchedulerWorker(_mainWorker, ReadyQueues, InQueue, Levels, MaxTotalInstructions, MaxSlices, AgingThresholdSlices, AgingThresholdBudget);
+            }
+            finally
+            {
+                for (int i = 0; i < Helpers.Length; i++)
+                    Helpers[i].Join();
+                SmpEnabled = false;
+                ReselectCurrentThread();
+            }
+        }
+
+        private bool RunSchedulerWorker(SchedulerWorker Worker, Queue<int>[] ReadyQueues, HashSet<int> InQueue, int Levels, ulong MaxTotalInstructions, uint MaxSlices, long AgingThresholdSlices, long AgingThresholdBudget)
+        {
+            t_worker = Worker;
+            lock (KernelLock)
+            {
+                try
+                {
+                    return RunSchedulerLoop(ReadyQueues, InQueue, Levels, MaxTotalInstructions, MaxSlices, AgingThresholdSlices, AgingThresholdBudget, ThreadOrder.Count);
+                }
+                catch (Exception ex) when (Worker.Index != 0)
+                {
+                    Utils.LogError($"[Scheduler] Worker {Worker.Index} stopped on an unhandled {ex.GetType().Name}: {ex.Message}");
+                    return false;
+                }
+                finally
+                {
+                    ReleaseDispatch(Worker);
+
+                    // Any worker leaving ends the run for all of them.
+                    SignalSchedulerExit();
+                }
+            }
+        }
+
+        private bool RunSchedulerLoop(Queue<int>[] ReadyQueues, HashSet<int> InQueue, int Levels, ulong MaxTotalInstructions, uint MaxSlices, long AgingThresholdSlices, long AgingThresholdBudget, int KnownThreadOrderCount)
+        {
+            const ulong SchedulerRescanInstructions = 1_000_000;
+            const long FullWakeupScanIntervalMs = 1;
+            const uint FullWakeupScanSliceLimit = 1024;
+            SchedulerWorker Self = Worker;
+            Self.WakeupScanRequired = true;
+
             while (true)
             {
-                SchedulerTick++;
-                MlfqSchedulerTick = SchedulerTick;
+                if (SchedulerExiting)
+                    return true;
+
+                long SchedulerTick = ++MlfqSchedulerTick;
 
                 if ((SchedulerTick & 0x7) == 0)
                     _emulator.ResolveCodeCache();
@@ -2776,7 +3102,10 @@ namespace Brovan.Core.Emulation
                     OS.Windows.RemoteProcessRequests.Drain(this);
 
                 if (Volatile.Read(ref TerminationRequested) != 0 && Interlocked.Exchange(ref TerminationRequested, 0) != 0)
+                {
+                    WinHelper?.HideDesktopWindow();
                     StopEmulation();
+                }
 
                 bool ThreadOrderChanged = ThreadOrder.Count != KnownThreadOrderCount;
                 bool AgingDue = AgingThresholdSlices > 0 && SchedulerTick % AgingThresholdSlices == 0;
@@ -2784,7 +3113,7 @@ namespace Brovan.Core.Emulation
                 {
                     RebuildMlfqReadyQueues(ReadyQueues, InQueue, Levels, SchedulerTick, AgingThresholdBudget, 1);
                     KnownThreadOrderCount = ThreadOrder.Count;
-                    WakeupScanRequired = false;
+                    Self.WakeupScanRequired = false;
                 }
                 else
                 {
@@ -2797,15 +3126,15 @@ namespace Brovan.Core.Emulation
                     }
 
                     // Comparing against the epoch the last scan observed, rather than a per-slice difference
-                    if (WakeupScanRequired || SchedulerRefreshRequested || WakeSignal.Current != LastScannedWakeEpoch)
+                    if (Self.WakeupScanRequired || SchedulerRefreshRequested || WakeSignal.Current != LastScannedWakeEpoch)
                     {
                         if (Debug)
-                            TriggerDebugMessage($"scheduler: wakeup scan required={WakeupScanRequired} refresh={SchedulerRefreshRequested} tick={SchedulerTick}");
+                            TriggerDebugMessage($"scheduler: wakeup scan required={Self.WakeupScanRequired} refresh={SchedulerRefreshRequested} tick={SchedulerTick}");
 
                         UpdateMlfqWakeups(ReadyQueues, InQueue, Levels, SchedulerTick);
                         KnownThreadOrderCount = ThreadOrder.Count;
                         SchedulerRefreshRequested = false;
-                        WakeupScanRequired = false;
+                        Self.WakeupScanRequired = false;
                     }
                 }
 
@@ -2814,7 +3143,7 @@ namespace Brovan.Core.Emulation
                     UpdateMlfqWakeups(ReadyQueues, InQueue, Levels, SchedulerTick, true);
                     KnownThreadOrderCount = ThreadOrder.Count;
                     SchedulerRefreshRequested = false;
-                    WakeupScanRequired = false;
+                    Self.WakeupScanRequired = false;
 
                     if (!TryDequeueMlfqThread(ReadyQueues, InQueue, Levels, out ImmaBeEmulatedOOO, out SelectedLevel))
                     {
@@ -2825,15 +3154,23 @@ namespace Brovan.Core.Emulation
                         // session requests until its creator resumes it.
                         if (StartSuspendedApplied && !StartSuspendedReleased)
                         {
-                            Thread.Sleep(IdleWaitSliceMs);
-                            WakeupScanRequired = true;
+                            IdleWait(IdleWaitSliceMs);
+                            Self.WakeupScanRequired = true;
+                            continue;
+                        }
+
+                        // A slice on another worker can still make threads runnable.
+                        if (DispatchedThreads != 0)
+                        {
+                            IdleWait(IdleWaitSliceMs);
+                            Self.WakeupScanRequired = true;
                             continue;
                         }
 
                         if (!HasLiveMlfqThread())
                         {
                             if (Debug)
-                                TriggerDebugMessage($"scheduler: finished no live threads total={Total} slices={Slices}");
+                                TriggerDebugMessage($"scheduler: finished no live threads total={_schedulerTotal} slices={_schedulerSlices}");
                             return true;
                         }
 
@@ -2841,25 +3178,44 @@ namespace Brovan.Core.Emulation
                         {
                             if (Debug)
                                 TriggerDebugMessage($"scheduler: no runnable thread, waiting up to {SleepMs}ms");
-                            Thread.Sleep(Math.Min(SleepMs, IdleWaitSliceMs));
+                            IdleWait(Math.Min(SleepMs, IdleWaitSliceMs));
                             WinHelper?.KuserSharedData?.RefreshIfUnhooked();
-                            WakeupScanRequired = true;
+                            Self.WakeupScanRequired = true;
                             continue;
                         }
 
                         if (HasActiveGetMessageWait())
                         {
-                            Thread.Sleep(IdleWaitSliceMs);
+                            IdleWait(IdleWaitSliceMs);
                             WinHelper?.KuserSharedData?.RefreshIfUnhooked();
-                            WakeupScanRequired = true;
+                            Self.WakeupScanRequired = true;
                             continue;
                         }
 
                         if (Debug)
-                            TriggerDebugMessage($"scheduler: no runnable thread and no pending wakeup total={Total} slices={Slices}");
+                            TriggerDebugMessage($"scheduler: no runnable thread and no pending wakeup total={_schedulerTotal} slices={_schedulerSlices}");
                         return true;
                     }
                 }
+
+                // Without a processor of its own the thread waits for one rather than sharing processor 0.
+                bool BoundThisSwitch = false;
+                if (SmpEnabled && !_emulator.IsThreadResident(ImmaBeEmulatedOOO.ThreadId))
+                {
+                    if (!BindThreadProcessor(ImmaBeEmulatedOOO))
+                    {
+                        EnqueueMlfqThread(ImmaBeEmulatedOOO, ReadyQueues, InQueue, Levels, SchedulerTick);
+                        IdleWait(IdleWaitSliceMs);
+                        Self.WakeupScanRequired = true;
+                        continue;
+                    }
+
+                    BoundThisSwitch = true;
+                }
+
+                ImmaBeEmulatedOOO.HostWorker = Self.Index;
+                Self.DispatchedThread = ImmaBeEmulatedOOO;
+                DispatchedThreads++;
 
                 if (CurrentThreadId != (int)ImmaBeEmulatedOOO.ThreadId)
                 {
@@ -2869,14 +3225,15 @@ namespace Brovan.Core.Emulation
                         TriggerDebugMessage($"scheduler: switch {CurrentThreadId} -> {ImmaBeEmulatedOOO.ThreadId} queue={SelectedLevel} state={ImmaBeEmulatedOOO.State} rip=0x{ImmaBeEmulatedOOO.Context?.RIP ?? 0:X}");
                 }
 
-                SwitchToThread((int)ImmaBeEmulatedOOO.ThreadId);
+                SwitchToThread((int)ImmaBeEmulatedOOO.ThreadId, BoundThisSwitch);
+
                 EmulatedThreadState StateBeforeSlice = ImmaBeEmulatedOOO.State;
                 ulong RipBeforeSlice = ImmaBeEmulatedOOO.Context?.RIP ?? 0;
                 ImmaBeEmulatedOOO.State = EmulatedThreadState.Running;
 
                 uint QuantumInstructions = MlfqQuanta[Math.Max(0, SelectedLevel)];
 
-                if (Debug && (Slices < 64 || (Slices & 0xFF) == 0))
+                if (Debug && (_schedulerSlices < 64 || (_schedulerSlices & 0xFF) == 0))
                 {
                     TriggerDebugMessage($"scheduler: run tid={ImmaBeEmulatedOOO.ThreadId} queue={SelectedLevel} quantum={QuantumInstructions} priority={ImmaBeEmulatedOOO.EffectivePriority} boost={ImmaBeEmulatedOOO.DynamicBoost} rip=0x{RipBeforeSlice:X}");
                 }
@@ -2907,11 +3264,10 @@ namespace Brovan.Core.Emulation
                     SchedulerRefreshRequested = false;
                 }
 
-                if (!ImmaBeEmulatedOOO.SwitchingContext)
-                {
-                    SaveContext(ImmaBeEmulatedOOO);
-                    _currentContextSaved = true;
-                }
+                SaveContext(ImmaBeEmulatedOOO);
+                CurrentContextSaved = true;
+
+                ReleaseDispatch(Self);
 
                 if (EscapeScheduler)
                 {
@@ -2933,15 +3289,15 @@ namespace Brovan.Core.Emulation
                 }
 
                 ImmaBeEmulatedOOO.InstructionsExecuted += SchedulerSliceWork;
-                Total += SchedulerSliceWork;
+                _schedulerTotal += SchedulerSliceWork;
 
                 bool TimedWaitRescanDue = false;
                 if (SchedulerSliceWork > 1)
                 {
-                    PendingSchedulerInstructions += SchedulerSliceWork;
-                    if (PendingSchedulerInstructions >= SchedulerRescanInstructions)
+                    _schedulerPendingInstructions += SchedulerSliceWork;
+                    if (_schedulerPendingInstructions >= SchedulerRescanInstructions)
                     {
-                        PendingSchedulerInstructions = 0;
+                        _schedulerPendingInstructions = 0;
                         TimedWaitRescanDue = true;
                     }
                 }
@@ -2957,7 +3313,7 @@ namespace Brovan.Core.Emulation
                         TimedWaitRescanDue = true;
                 }
 
-                Slices++;
+                _schedulerSlices++;
                 WinHelper?.KuserSharedData?.RefreshIfUnhooked();
                 ImmaBeEmulatedOOO.LastRunTick = SchedulerTick;
 
@@ -2989,10 +3345,24 @@ namespace Brovan.Core.Emulation
                 else if (ImmaBeEmulatedOOO.State != EmulatedThreadState.Terminated)
                     ImmaBeEmulatedOOO.DynamicBoost = ClampInt(ImmaBeEmulatedOOO.DynamicBoost - 1, -16, 16);
 
+                // Scans skipped the thread while it was dispatched, so its own wait is checked here.
+                if (SmpEnabled && ImmaBeEmulatedOOO.State == EmulatedThreadState.Waiting && ImmaBeEmulatedOOO.WaitActive)
+                {
+                    long EarliestDeadline = EarliestWaitDeadline;
+                    UpdateMlfqThreadWakeup(ImmaBeEmulatedOOO, ReadyQueues, InQueue, Levels, SchedulerTick, EmulatedTickCount64, WakeSignal.Current, ref EarliestDeadline);
+                    EarliestWaitDeadline = EarliestDeadline;
+                }
+
                 if (ImmaBeEmulatedOOO.State == EmulatedThreadState.Ready || ImmaBeEmulatedOOO.State == EmulatedThreadState.Exception)
                     EnqueueMlfqThread(ImmaBeEmulatedOOO, ReadyQueues, InQueue, Levels, SchedulerTick);
                 else if (ImmaBeEmulatedOOO.State == EmulatedThreadState.Terminated)
                 {
+                    // The thread is off its worker now, so a release the terminating side skipped runs here.
+                    Guest.OnThreadTerminated(this, ImmaBeEmulatedOOO);
+                    ReleaseThreadProcessor(ImmaBeEmulatedOOO);
+                    // A thread that ended its own slice stays in the table until the slice is fully over.
+                    if (ImmaBeEmulatedOOO.Unreferenced)
+                        Threads.Remove(ImmaBeEmulatedOOO.ThreadId);
                     TrimDeadThreadsFromOrder();
                     KnownThreadOrderCount = ThreadOrder.Count;
                 }
@@ -3001,23 +3371,31 @@ namespace Brovan.Core.Emulation
                     && ImmaBeEmulatedOOO.WaitDeadline != -1 && ImmaBeEmulatedOOO.WaitDeadline < EarliestWaitDeadline)
                     EarliestWaitDeadline = ImmaBeEmulatedOOO.WaitDeadline;
 
-                WakeupScanRequired = SliceRequestedRefresh || TimedWaitRescanDue || ThreadOrder.Count != KnownThreadOrderCount;
+                Self.WakeupScanRequired = SliceRequestedRefresh || TimedWaitRescanDue || ThreadOrder.Count != KnownThreadOrderCount;
 
-                if (Debug && (Slices <= 64 || (Slices & 0xFF) == 0 || ImmaBeEmulatedOOO.State != StateBeforeSlice || SliceRequestedRefresh || TimedWaitRescanDue))
+                if (Debug && (_schedulerSlices <= 64 || (_schedulerSlices & 0xFF) == 0 || ImmaBeEmulatedOOO.State != StateBeforeSlice || SliceRequestedRefresh || TimedWaitRescanDue))
                 {
-                    TriggerDebugMessage($"scheduler: slice tid={ImmaBeEmulatedOOO.ThreadId} {StateBeforeSlice}->{ImmaBeEmulatedOOO.State} work={SchedulerSliceWork} total={Total} rip=0x{RipBeforeSlice:X}->0x{ImmaBeEmulatedOOO.Context?.RIP ?? 0:X} refresh={SliceRequestedRefresh} rescanDue={TimedWaitRescanDue} boost={ImmaBeEmulatedOOO.DynamicBoost}");
+                    TriggerDebugMessage($"scheduler: slice tid={ImmaBeEmulatedOOO.ThreadId} {StateBeforeSlice}->{ImmaBeEmulatedOOO.State} work={SchedulerSliceWork} total={_schedulerTotal} rip=0x{RipBeforeSlice:X}->0x{ImmaBeEmulatedOOO.Context?.RIP ?? 0:X} refresh={SliceRequestedRefresh} rescanDue={TimedWaitRescanDue} boost={ImmaBeEmulatedOOO.DynamicBoost}");
                 }
 
-                if (MaxTotalInstructions != 0 && Total >= MaxTotalInstructions)
+                // Between slices a worker runs no thread, so nothing may treat the parked one as current.
+                if (SmpEnabled)
+                {
+                    Self.LastThreadId = Self.CurrentThreadId;
+                    Self.CurrentThreadId = -1;
+                    Self.CurrentThreadCache = null;
+                }
+
+                if (MaxTotalInstructions != 0 && _schedulerTotal >= MaxTotalInstructions)
                 {
                     if (Debug)
-                        TriggerDebugMessage($"scheduler: max instruction budget reached total={Total} slices={Slices}");
+                        TriggerDebugMessage($"scheduler: max instruction budget reached total={_schedulerTotal} slices={_schedulerSlices}");
                     return true;
                 }
-                if (MaxSlices != 0 && Slices >= MaxSlices)
+                if (MaxSlices != 0 && _schedulerSlices >= MaxSlices)
                 {
                     if (Debug)
-                        TriggerDebugMessage($"scheduler: max slice budget reached total={Total} slices={Slices}");
+                        TriggerDebugMessage($"scheduler: max slice budget reached total={_schedulerTotal} slices={_schedulerSlices}");
                     return true;
                 }
             }
@@ -3148,6 +3526,7 @@ namespace Brovan.Core.Emulation
         {
             if (Debug)
                 TriggerDebugMessage($"cpu: syscall instruction at 0x{ReadRegister(IPRegister):X}");
+            long EpochBeforeCallback = WakeSignal.Current;
             try
             {
                 Guest.TryHandleSyscall(this);
@@ -3159,6 +3538,8 @@ namespace Brovan.Core.Emulation
                 SchedulerRefreshRequested = true;
                 Utils.LogError($"[GuestSyscall] Error: {ex.Message}");
             }
+
+            ScanWakeupsAfterCallback(EpochBeforeCallback);
         }
 
         public void Start()
@@ -3389,6 +3770,7 @@ namespace Brovan.Core.Emulation
             {
                 EmuThread.State = EmulatedThreadState.Terminated;
             }
+            _emulator.StopAllProcessors();
             return _emulator.StopEmulation();
         }
 

--- a/Brovan/Core/Emulation/BinaryEmulatorHelper.cs
+++ b/Brovan/Core/Emulation/BinaryEmulatorHelper.cs
@@ -124,6 +124,7 @@ namespace Brovan.Core.Emulation
         ulong CreateInitialThread(BinaryEmulator Instance);
         EmulatedThread CreateEmulatedThread(BinaryEmulator Instance, ulong StartAddress, string Name = null!, ulong Parameter = 0, ulong? StackSizeOverride = null, int BasePriority = 8);
         void OnThreadContextLoaded(BinaryEmulator Instance, EmulatedThread Thread);
+        void OnThreadTerminated(BinaryEmulator Instance, EmulatedThread Thread);
         bool HasPendingGuestWork(BinaryEmulator Instance, EmulatedThread Thread);
         bool IsHandleSignaled(BinaryEmulator Instance, ulong Handle);
         bool ExecuteThreadSlice(BinaryEmulator Instance, EmulatedThread Thread, uint QuantumInstructions, out bool State);

--- a/Brovan/Core/Emulation/Guests/GenericGuest.cs
+++ b/Brovan/Core/Emulation/Guests/GenericGuest.cs
@@ -200,6 +200,10 @@ namespace Brovan.Core.Emulation.Guests
         {
         }
 
+        public void OnThreadTerminated(BinaryEmulator Instance, EmulatedThread Thread)
+        {
+        }
+
         public bool HasPendingGuestWork(BinaryEmulator Instance, EmulatedThread Thread)
         {
             return false;

--- a/Brovan/Core/Emulation/Guests/LinuxGuest.cs
+++ b/Brovan/Core/Emulation/Guests/LinuxGuest.cs
@@ -337,6 +337,7 @@ namespace Brovan.Core.Emulation.Guests
             if (!Instance.IsArchX86Guest)
                 throw new Exception("Linux guest supports only x86/x64.");
 
+            Helper.Emulator = Instance;
             LoadedModules.Clear();
 
             ReadOnlySpan<byte> Data = Binary.GetBinaryData();
@@ -811,15 +812,17 @@ namespace Brovan.Core.Emulation.Guests
             return Thread;
         }
 
+        public void OnThreadTerminated(BinaryEmulator Instance, EmulatedThread Thread)
+        {
+        }
+
         public void OnThreadContextLoaded(BinaryEmulator Instance, EmulatedThread Thread)
         {
             LinuxThreadState State = Thread?.GuestState as LinuxThreadState;
             if (State == null)
                 return;
 
-            Helper.CurrentThreadId = (int)Thread.ThreadId;
             Helper.RegisterThread(Thread);
-            Helper.CpuidEnabled = State.CpuidEnabled;
             if (Instance.IsX64Guest)
             {
                 Instance._emulator.WriteRegister((int)Registers.UC_X86_REG_FS_BASE, State.FsBase);
@@ -869,7 +872,6 @@ namespace Brovan.Core.Emulation.Guests
             ThreadState = Thread.GuestState as LinuxThreadState;
             if (ThreadState != null)
             {
-                ThreadState.CpuidEnabled = Helper.CpuidEnabled;
                 if (Instance.IsX64Guest)
                 {
                     ThreadState.FsBase = Instance.ReadRegister(Registers.UC_X86_REG_FS_BASE);

--- a/Brovan/Core/Emulation/Guests/WindowsGuest.cs
+++ b/Brovan/Core/Emulation/Guests/WindowsGuest.cs
@@ -274,6 +274,11 @@ namespace Brovan.Core.Emulation.Guests
             Instance.RunMlfqScheduler();
         }
 
+        public void OnThreadTerminated(BinaryEmulator Instance, EmulatedThread Thread)
+        {
+            Instance.WinHelper?.ReleaseThreadResources(Thread);
+        }
+
         public void OnThreadContextLoaded(BinaryEmulator Instance, EmulatedThread Thread)
         {
             if (Thread == null)
@@ -1237,6 +1242,7 @@ namespace Brovan.Core.Emulation.Guests
                 InitialRSP -= 0x20;
 
                 ulong ContextAddress = Instance.BuildInitialContext(RtlUserThreadStart, InitialRSP, StartAddress, Parameter);
+                State.InitialContext = ContextAddress;
                 Thread.Context.RSP = InitialRSP;
                 Thread.Context.RCX = ContextAddress;
                 Thread.Context.RDX = _ntdllModule?.MappedBase ?? 0;
@@ -1248,6 +1254,7 @@ namespace Brovan.Core.Emulation.Guests
                 Instance._emulator.WriteMemory(ContextEsp, 0u);
 
                 ulong ContextAddress = Instance.BuildInitialContext32(RtlUserThreadStart, ContextEsp, StartAddress, Parameter);
+                State.InitialContext = ContextAddress;
 
                 ulong ThunkEsp = StackTop - 0x40;
                 ThunkEsp -= 4;
@@ -1396,8 +1403,7 @@ namespace Brovan.Core.Emulation.Guests
                 {
                     Instance.TriggerEventMessage($"[!] Another process in the session asked this one to stop with exit code 0x{ExitCode:X}.", LogFlags.Important);
                     GuestSession.PublishExit(ExitCode);
-                    Instance.WinHelper.HideDesktopWindow();
-                    Instance.StopEmulation();
+                    Instance.RequestTermination();
                 });
         }
 

--- a/Brovan/Core/Emulation/KvmBinding/Constants.cs
+++ b/Brovan/Core/Emulation/KvmBinding/Constants.cs
@@ -68,10 +68,15 @@ namespace Brovan.Core.Emulation
         public const uint KvmIoGetDebugRegisters = 0x8080AEA1;
         public const uint KvmIoSetDebugRegisters = 0x4080AEA2;
         public const uint KvmIoGetTscKhz = 0xAEA3;
+        public const uint KvmIoSetDeviceAttr = 0x4018AEE1;
+        public const uint KvmIoGetDeviceAttr = 0x4018AEE2;
+        public const uint VcpuTscCtrl = 0;
+        public const ulong VcpuTscOffset = 0;
 
         public const int CapNrMemslots = 10;
         public const int CapGetTscKhz = 61;
         public const int CapMaxVcpus = 66;
+        public const int CapVcpuAttributes = 127;
         public const int CapSyncRegs = 74;
         public const int CapXsave = 84;
         public const int CapImmediateExit = 136;

--- a/Brovan/Core/Emulation/KvmBinding/Kvm.cs
+++ b/Brovan/Core/Emulation/KvmBinding/Kvm.cs
@@ -1420,6 +1420,12 @@ namespace Brovan.Core.Emulation
             {
                 RemoveHooks();
 
+                // The maintenance thread reads run pages and fds of every processor, so it has to be gone
+                // before they are released.
+                Thread Maintenance = _maintenanceThread;
+                _maintenanceThread = null;
+                Maintenance?.Join();
+
                 for (int i = 0; i < _processors.Count; i++)
                 {
                     VirtualProcessor vp = _processors[i];

--- a/Brovan/Core/Emulation/KvmBinding/Kvm.cs
+++ b/Brovan/Core/Emulation/KvmBinding/Kvm.cs
@@ -39,6 +39,9 @@ namespace Brovan.Core.Emulation
         private const int MaxVirtualProcessors = 1024;
         private int _maxMemslots;
         private bool _supportsXsave;
+        private bool _supportsVcpuAttributes;
+        private bool _tscOffsetKnown;
+        private ulong _tscOffset;
         private int _nextSlotId;
         private readonly List<int> _freeSlotIds = new();
         private readonly Dictionary<ulong, InstalledSlot> _activeSlots = new();
@@ -58,6 +61,8 @@ namespace Brovan.Core.Emulation
         private readonly Dictionary<ulong, InstalledSlot> _desiredSlots = new();
         private readonly List<ulong> _staleSlotKeys = new();
         private readonly List<ulong> _activeSlotStarts = new();
+        private readonly HashSet<ulong> _keptSlotStarts = new();
+        private const int SlotHeadroom = 64;
         private bool _fullRebuildRequired = true;
         private readonly List<DirtyRange> _dirtyRanges = new();
         private const int MaxDirtyRanges = 16;
@@ -73,40 +78,76 @@ namespace Brovan.Core.Emulation
         private ulong _syscallTrapPageGpa;
         private ulong _exceptionStubPageGpa;
         private ulong _exceptionIdtPageGpa;
-        private ulong _exceptionTssPageGpa;
-        private ulong _exceptionStackPageGpa;
         private ulong _gdtPageGpa;
+        private const ulong ExceptionStackPages = 2;
 
         private readonly object _vcpuLock = new();
 
         private sealed class VirtualProcessor
         {
+            public Kvm Owner;
             public int Index;
             public int Fd = -1;
             public IntPtr RunPtr;
             public uint ThreadId;
+            public ulong GdtPageGpa;
+            public ulong TssPageGpa;
 
             // Parked in the trap page with kernel CS/SS, so no segment write reaches the vCPU.
             public bool InSyscallStub;
+
+            public bool MmioCompletionPending;
+            public bool FaultRegistersSaved;
+            public LinuxKvmRegisters FaultRegisters;
+
+            public volatile bool StopRequested;
+            public volatile bool Running;
+            public int HostThreadId;
+            public int HostTid;
+            public bool SingleStepRequested;
+            public long SliceDeadlineTimestamp;
+
+            // Bumped when the vCPU leaves a guest thread. A selection made before the bump is stale.
+            public long Binding;
         }
 
         // The trap page holds hlt at 0 and sysretq at 8.
         private const ulong SyscallReturnOffset = 8;
 
-        // One vCPU per guest thread. Threads past the limit share vCPU 0 and swap state each slice.
-        private VirtualProcessor _vp;
+        // One vCPU per guest thread. A thread that cannot get one waits.
         private readonly List<VirtualProcessor> _processors = new();
+        private VirtualProcessor[] _processorSnapshot = Array.Empty<VirtualProcessor>();
         private readonly Stack<VirtualProcessor> _idleProcessors = new();
         private readonly Dictionary<uint, VirtualProcessor> _threadProcessors = new();
         private int _processorLimit;
-        private VirtualProcessor _runningProcessor;
-        private int _emulateManagedThreadId;
-        private int _emulateTid;
+
+        [ThreadStatic]
+        private static VirtualProcessor t_vp;
+        [ThreadStatic]
+        private static long t_vpBinding;
+
+        private VirtualProcessor CurrentVp
+        {
+            get
+            {
+                VirtualProcessor vp = t_vp;
+                return vp != null && ReferenceEquals(vp.Owner, this) && vp.Binding == t_vpBinding
+                    ? vp
+                    : _processors[0];
+            }
+        }
+
+        private static void SelectProcessor(VirtualProcessor vp)
+        {
+            t_vp = vp;
+            t_vpBinding = vp.Binding;
+        }
+
+        private object _runLock;
 
         // KVM cannot end a run after a set instruction count, so a slice is bounded by wall clock.
         private const int BoundedSliceMilliseconds = 10;
         private Thread _maintenanceThread;
-        private long _sliceDeadlineTimestamp;
 
         // A vCPU in guest mode leaves only for a signal.
         private static int _kickSignal;
@@ -120,8 +161,6 @@ namespace Brovan.Core.Emulation
         private readonly List<IntPtr> _liveHookHandles = new();
 
         private bool _hasCpuIdHook;
-        private bool _hasRdtscHook;
-        private bool _hasRdtscpHook;
         private bool _hasInvalidHook;
         private bool _scanPreRunInstructions;
 
@@ -130,11 +169,6 @@ namespace Brovan.Core.Emulation
 
         private int _disposed;
         private int _disposing;
-        private volatile bool _stopRequested;
-        private bool _mmioCompletionPending;
-        private bool _faultRegistersSaved;
-        private LinuxKvmRegisters _faultRegisters;
-        private bool _singleStepRequested;
 
         public bool NoHooks;
         public static bool ThrowDisposed = true;
@@ -143,7 +177,8 @@ namespace Brovan.Core.Emulation
         public bool SupportsXsave => _supportsXsave;
         private bool Disposing => Volatile.Read(ref _disposing) == 1;
 
-        private KvmErrors _error;
+        [ThreadStatic]
+        private static KvmErrors _error;
 
         private sealed class MappedPage
         {
@@ -231,7 +266,7 @@ namespace Brovan.Core.Emulation
             InitializeGdt();
             InitializeSyscallTrapPage();
             InitializeExceptionHandling();
-            _vp = CreateProcessor(0);
+            SelectProcessor(CreateProcessor(0));
             _timestampCounterFrequency = QueryTimestampCounterFrequency();
             RebuildMappings();
         }
@@ -244,7 +279,7 @@ namespace Brovan.Core.Emulation
         {
             if (KvmNative.ioctl(_systemFd, KvmConstants.KvmIoCheckExtension, KvmConstants.CapGetTscKhz) <= 0)
                 return 0;
-            int khz = KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoGetTscKhz, IntPtr.Zero);
+            int khz = KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoGetTscKhz, IntPtr.Zero);
             return khz <= 0 ? 0 : (ulong)khz * 1000;
         }
 
@@ -256,7 +291,7 @@ namespace Brovan.Core.Emulation
 
             try
             {
-                value = GetMsr(_vp, KvmConstants.MsrTsc);
+                value = GetMsr(CurrentVp, KvmConstants.MsrTsc);
                 return true;
             }
             catch (KvmException)
@@ -883,7 +918,7 @@ namespace Brovan.Core.Emulation
 
             if (_mappingsDirty) RebuildMappings();
 
-            VirtualProcessor vp = _vp;
+            VirtualProcessor vp = CurrentVp;
             ref LinuxKvmRun run = ref GetRunRef(vp);
 
             ClearTrapFlag();
@@ -891,40 +926,41 @@ namespace Brovan.Core.Emulation
             run.Regs.Rip = start;
             MarkRegistersDirty();
 
-            _stopRequested = false;
-            _mmioCompletionPending = false;
-            _faultRegistersSaved = false;
-            _singleStepRequested = count == 1;
+            vp.StopRequested = false;
+            vp.MmioCompletionPending = false;
+            vp.FaultRegistersSaved = false;
+            vp.SingleStepRequested = count == 1;
             run.ImmediateExit = 0;
 
-            if (_emulateManagedThreadId != Environment.CurrentManagedThreadId)
+            if (vp.HostThreadId != Environment.CurrentManagedThreadId)
             {
-                _emulateManagedThreadId = Environment.CurrentManagedThreadId;
-                Volatile.Write(ref _emulateTid, KvmNative.gettid());
+                vp.HostThreadId = Environment.CurrentManagedThreadId;
+                Volatile.Write(ref vp.HostTid, KvmNative.gettid());
             }
-            Volatile.Write(ref _runningProcessor, vp);
 
             bool bounded = count != 0;
             if (bounded)
             {
                 EnsureMaintenanceThread();
-                Volatile.Write(ref _sliceDeadlineTimestamp,
+                Volatile.Write(ref vp.SliceDeadlineTimestamp,
                     Stopwatch.GetTimestamp() + (Stopwatch.Frequency * BoundedSliceMilliseconds) / 1000);
             }
 
-            if (_singleStepRequested)
+            if (vp.SingleStepRequested)
             {
                 run.Regs.Rflags |= 0x100UL;
                 MarkRegistersDirty();
             }
+
+            bool releaseRunLock = _runLock != null && Monitor.IsEntered(_runLock);
 
             try
             {
                 while (true)
                 {
                     // Zero means the deadline was consumed, by the timer or by a kick.
-                    bool sliceOver = _stopRequested || (bounded && Volatile.Read(ref _sliceDeadlineTimestamp) == 0);
-                    if (sliceOver && !_mmioCompletionPending)
+                    bool sliceOver = vp.StopRequested || (bounded && Volatile.Read(ref vp.SliceDeadlineTimestamp) == 0);
+                    if (sliceOver && !vp.MmioCompletionPending)
                         break;
 
                     if (HandlePreRunInstruction()) continue;
@@ -933,30 +969,25 @@ namespace Brovan.Core.Emulation
 
                     if (vp.InSyscallStub) PrepareSyscallReturn(vp, ref run);
 
-                    int rc;
-                    lock (_vcpuLock)
-                    {
-                        rc = KvmNative.ioctl(vp.Fd, KvmConstants.KvmIoRun, IntPtr.Zero);
-                    }
+                    int rc = RunProcessor(vp, releaseRunLock, out int errno);
 
                     if (vp.InSyscallStub) CompleteSyscallReturn(vp, ref run);
 
-                    if (_mmioCompletionPending)
+                    if (vp.MmioCompletionPending)
                     {
-                        _mmioCompletionPending = false;
-                        if (_faultRegistersSaved && (rc < 0 || run.ExitReason != KvmConstants.ExitMmio))
+                        vp.MmioCompletionPending = false;
+                        if (vp.FaultRegistersSaved && (rc < 0 || run.ExitReason != KvmConstants.ExitMmio))
                         {
-                            _faultRegistersSaved = false;
-                            SetRegisters(_faultRegisters);
+                            vp.FaultRegistersSaved = false;
+                            SetRegisters(vp.FaultRegisters);
                         }
                     }
 
                     if (rc < 0)
                     {
-                        int errno = Marshal.GetLastWin32Error();
                         if (errno == KvmNative.ErrnoEintr)
                         {
-                            ClearImmediateExit(ref run, bounded);
+                            ClearImmediateExit(vp, ref run, bounded);
                             continue;
                         }
 
@@ -967,10 +998,10 @@ namespace Brovan.Core.Emulation
                     switch (run.ExitReason)
                     {
                         case KvmConstants.ExitHlt:
-                            if (HandleHltExit()) continue;
+                            if (HandleHltExit(vp)) continue;
                             return _error == KvmErrors.Ok;
                         case KvmConstants.ExitMmio:
-                            if (!HandleMmioExit(ref run))
+                            if (!HandleMmioExit(vp, ref run))
                                 StopEmulation();
                             continue;
                         case KvmConstants.ExitException:
@@ -989,7 +1020,7 @@ namespace Brovan.Core.Emulation
                             _error = KvmErrors.Ok;
                             return true;
                         case KvmConstants.ExitIntr:
-                            ClearImmediateExit(ref run, bounded);
+                            ClearImmediateExit(vp, ref run, bounded);
                             continue;
                         case KvmConstants.ExitShutdown:
                             _error = KvmErrors.Exception;
@@ -1011,26 +1042,43 @@ namespace Brovan.Core.Emulation
             }
             finally
             {
-                Volatile.Write(ref _sliceDeadlineTimestamp, 0);
-                Volatile.Write(ref _runningProcessor, null);
+                Volatile.Write(ref vp.SliceDeadlineTimestamp, 0);
 
-                if (_singleStepRequested)
+                if (vp.SingleStepRequested)
                 {
-                    _singleStepRequested = false;
+                    vp.SingleStepRequested = false;
                     ClearTrapFlag();
                 }
             }
         }
 
-        // KVM never clears immediate_exit, and leaving it set makes every later KVM_RUN return -EINTR.
-        private void ClearImmediateExit(ref LinuxKvmRun run, bool bounded)
+        private int RunProcessor(VirtualProcessor vp, bool releaseRunLock, out int errno)
         {
-            if (_stopRequested) return;
-            if (bounded && Volatile.Read(ref _sliceDeadlineTimestamp) == 0) return;
+            int rc;
+            vp.Running = true;
+            if (releaseRunLock) Monitor.Exit(_runLock);
+            try
+            {
+                rc = KvmNative.ioctl(vp.Fd, KvmConstants.KvmIoRun, IntPtr.Zero);
+                errno = rc < 0 ? Marshal.GetLastWin32Error() : 0;
+            }
+            finally
+            {
+                if (releaseRunLock) Monitor.Enter(_runLock);
+                vp.Running = false;
+            }
+            return rc;
+        }
+
+        // KVM never clears immediate_exit, and leaving it set makes every later KVM_RUN return -EINTR.
+        private static void ClearImmediateExit(VirtualProcessor vp, ref LinuxKvmRun run, bool bounded)
+        {
+            if (vp.StopRequested) return;
+            if (bounded && Volatile.Read(ref vp.SliceDeadlineTimestamp) == 0) return;
 
             run.ImmediateExit = 0;
             Interlocked.MemoryBarrier();
-            if (bounded && Volatile.Read(ref _sliceDeadlineTimestamp) == 0)
+            if (bounded && Volatile.Read(ref vp.SliceDeadlineTimestamp) == 0)
                 run.ImmediateExit = 1;
         }
 
@@ -1038,14 +1086,41 @@ namespace Brovan.Core.Emulation
         {
             if (DisposedCheck()) return false;
 
-            _stopRequested = true;
-            if (Environment.CurrentManagedThreadId == _emulateManagedThreadId)
-                GetRunRef().ImmediateExit = 1;
+            VirtualProcessor vp = CurrentVp;
+            vp.StopRequested = true;
+            if (Environment.CurrentManagedThreadId == vp.HostThreadId)
+                GetRunRef(vp).ImmediateExit = 1;
             else
-                KickRunningProcessor();
+                KickProcessor(vp);
 
             _error = KvmErrors.Ok;
             return true;
+        }
+
+        public void UseRunLock(object runLock) => _runLock = runLock;
+
+        public void StopThread(uint threadId)
+        {
+            if (Disposed || Disposing) return;
+            if (!_threadProcessors.TryGetValue(threadId, out VirtualProcessor vp)) return;
+
+            vp.StopRequested = true;
+            if (vp.Running)
+                KickProcessor(vp);
+        }
+
+        public void StopAllProcessors()
+        {
+            if (Disposed || Disposing) return;
+
+            VirtualProcessor[] processors = Volatile.Read(ref _processorSnapshot);
+            for (int i = 0; i < processors.Length; i++)
+            {
+                VirtualProcessor vp = processors[i];
+                vp.StopRequested = true;
+                if (vp.Running)
+                    KickProcessor(vp);
+            }
         }
 
         private void EnsureMaintenanceThread()
@@ -1066,52 +1141,55 @@ namespace Brovan.Core.Emulation
         {
             while (!Disposed && !Disposing)
             {
-                EnforceSliceDeadline();
+                EnforceSliceDeadlines();
                 Thread.Sleep(1);
             }
         }
 
         public bool TryLimitSlice(int microseconds)
         {
+            VirtualProcessor vp = CurrentVp;
             long limit = Stopwatch.GetTimestamp() + (Stopwatch.Frequency * microseconds) / 1_000_000;
             while (true)
             {
-                long deadline = Volatile.Read(ref _sliceDeadlineTimestamp);
+                long deadline = Volatile.Read(ref vp.SliceDeadlineTimestamp);
                 if (deadline == 0)
                     return false;
                 if (limit >= deadline)
                     return true;
-                if (Interlocked.CompareExchange(ref _sliceDeadlineTimestamp, limit, deadline) == deadline)
+                if (Interlocked.CompareExchange(ref vp.SliceDeadlineTimestamp, limit, deadline) == deadline)
                     return true;
             }
         }
 
-        private void EnforceSliceDeadline()
+        private void EnforceSliceDeadlines()
         {
-            long deadline = Volatile.Read(ref _sliceDeadlineTimestamp);
-            if (deadline == 0 || Stopwatch.GetTimestamp() < deadline)
-                return;
-
             if (Disposed || Disposing)
                 return;
 
-            if (Interlocked.CompareExchange(ref _sliceDeadlineTimestamp, 0, deadline) != deadline)
-                return;
+            VirtualProcessor[] processors = Volatile.Read(ref _processorSnapshot);
+            long now = Stopwatch.GetTimestamp();
+            for (int i = 0; i < processors.Length; i++)
+            {
+                VirtualProcessor vp = processors[i];
+                long deadline = Volatile.Read(ref vp.SliceDeadlineTimestamp);
+                if (deadline == 0 || now < deadline)
+                    continue;
 
-            KickRunningProcessor();
+                if (Interlocked.CompareExchange(ref vp.SliceDeadlineTimestamp, 0, deadline) != deadline)
+                    continue;
+
+                KickProcessor(vp);
+            }
         }
 
         // immediate_exit stops a run that has not entered the guest yet, the signal stops one that has.
-        private void KickRunningProcessor()
+        private void KickProcessor(VirtualProcessor vp)
         {
-            VirtualProcessor vp = Volatile.Read(ref _runningProcessor);
-            if (vp == null)
-                return;
-
             Volatile.Write(ref GetRunRef(vp).ImmediateExit, 1);
             Interlocked.MemoryBarrier();
 
-            int tid = Volatile.Read(ref _emulateTid);
+            int tid = Volatile.Read(ref vp.HostTid);
             if (tid != 0)
                 KvmNative.tgkill(_pid, tid, _kickSignal);
         }
@@ -1512,7 +1590,7 @@ namespace Brovan.Core.Emulation
         }
 
         private unsafe ref LinuxKvmRun GetRunRef()
-            => ref Unsafe.AsRef<LinuxKvmRun>((void*)_vp.RunPtr);
+            => ref Unsafe.AsRef<LinuxKvmRun>((void*)CurrentVp.RunPtr);
 
         private static unsafe ref LinuxKvmRun GetRunRef(VirtualProcessor vp)
             => ref Unsafe.AsRef<LinuxKvmRun>((void*)vp.RunPtr);
@@ -1556,6 +1634,7 @@ namespace Brovan.Core.Emulation
                 _maxMemslots = DefaultMemslotCount;
 
             _supportsXsave = KvmNative.ioctl(_systemFd, KvmConstants.KvmIoCheckExtension, KvmConstants.CapXsave) > 0;
+            _supportsVcpuAttributes = KvmNative.ioctl(_systemFd, KvmConstants.KvmIoCheckExtension, KvmConstants.CapVcpuAttributes) > 0;
 
             const ulong requiredSync = KvmConstants.SyncGeneralRegisters | KvmConstants.SyncSpecialRegisters;
             int syncRegs = KvmNative.ioctl(_systemFd, KvmConstants.KvmIoCheckExtension, KvmConstants.CapSyncRegs);
@@ -1612,11 +1691,69 @@ namespace Brovan.Core.Emulation
                 throw new KvmException("mmap(KVM_RUN) failed", errno);
             }
 
-            VirtualProcessor vp = new VirtualProcessor { Index = index, Fd = fd, RunPtr = runPtr };
+            VirtualProcessor vp = new VirtualProcessor { Owner = this, Index = index, Fd = fd, RunPtr = runPtr };
+
+            try
+            {
+                AllocateProcessorTables(vp);
+                InitializeCpuid(vp);
+                InitializeVirtualProcessorState(vp);
+                AlignTimestampCounter(vp);
+            }
+            catch
+            {
+                KvmNative.munmap(runPtr, (UIntPtr)_runMmapSize);
+                KvmNative.close(fd);
+                throw;
+            }
+
             _processors.Add(vp);
-            InitializeCpuid(vp);
-            InitializeVirtualProcessorState(vp);
+            Volatile.Write(ref _processorSnapshot, _processors.ToArray());
             return vp;
+        }
+
+        private unsafe void AllocateProcessorTables(VirtualProcessor vp)
+        {
+            vp.GdtPageGpa = AllocateInternalPage(false);
+            vp.TssPageGpa = AllocateInternalPage(false);
+            ulong stackSize = ExceptionStackPages * KvmConstants.PageSize;
+            ulong stackTop = AllocateInternalRange(stackSize, KvmMemoryPermission.ReadWrite) + stackSize;
+
+            if (!_mappedPages.TryGetValue(_gdtPageGpa, out MappedPage template)
+                || !_mappedPages.TryGetValue(vp.GdtPageGpa, out MappedPage gdtPage)
+                || !_mappedPages.TryGetValue(vp.TssPageGpa, out MappedPage tssPage))
+                throw new KvmException("Failed to allocate the processor tables.");
+
+            byte* gdt = (byte*)gdtPage.HostPage;
+            Unsafe.CopyBlockUnaligned(gdt, (byte*)template.HostPage, (uint)KvmConstants.PageSize);
+            WriteTssDescriptor(gdt, vp.TssPageGpa);
+
+            byte* tss = (byte*)tssPage.HostPage;
+            Unsafe.WriteUnaligned(tss + 0x04, stackTop);
+            Unsafe.WriteUnaligned(tss + 0x24, stackTop);
+            Unsafe.WriteUnaligned(tss + 0x66, (ushort)0x68);
+        }
+
+        private static unsafe void WriteTssDescriptor(byte* gdt, ulong tssBase)
+        {
+            int tssIndex = KvmConstants.TssSelector >> 3;
+            uint tssLimit = 0x67;
+            gdt[tssIndex * 8 + 0] = (byte)(tssLimit & 0xFF);
+            gdt[tssIndex * 8 + 1] = (byte)((tssLimit >> 8) & 0xFF);
+            gdt[tssIndex * 8 + 2] = (byte)(tssBase & 0xFF);
+            gdt[tssIndex * 8 + 3] = (byte)((tssBase >> 8) & 0xFF);
+            gdt[tssIndex * 8 + 4] = (byte)((tssBase >> 16) & 0xFF);
+            gdt[tssIndex * 8 + 5] = (byte)(0x89 | 0x80);
+            gdt[tssIndex * 8 + 6] = (byte)(((tssLimit >> 16) & 0xF) | 0x00);
+            gdt[tssIndex * 8 + 7] = (byte)((tssBase >> 24) & 0xFF);
+            gdt[tssIndex * 8 + 8] = (byte)((tssBase >> 32) & 0xFF);
+            gdt[tssIndex * 8 + 9] = (byte)((tssBase >> 40) & 0xFF);
+            gdt[tssIndex * 8 + 10] = (byte)((tssBase >> 48) & 0xFF);
+            gdt[tssIndex * 8 + 11] = (byte)((tssBase >> 56) & 0xFF);
+            gdt[tssIndex * 8 + 12] = 0;
+            gdt[tssIndex * 8 + 13] = 0;
+            gdt[tssIndex * 8 + 14] = 0;
+            gdt[tssIndex * 8 + 15] = 0;
         }
 
         private unsafe void InitializeCpuid(VirtualProcessor vp)
@@ -1664,12 +1801,12 @@ namespace Brovan.Core.Emulation
             sregs.Cr4 = 0x620UL;
             sregs.Cr3 = _pml4Gpa;
             sregs.Efer = (1UL << 0) | (1UL << 8) | (1UL << 10) | (1UL << 11);
-            sregs.Gdt.Base = _gdtPageGpa;
+            sregs.Gdt.Base = vp.GdtPageGpa;
             sregs.Gdt.Limit = 0x48;
             sregs.Idt.Base = _exceptionIdtPageGpa;
             sregs.Idt.Limit = (ushort)(KvmConstants.ExceptionVectorCount * 16 - 1);
             sregs.Tr.Selector = KvmConstants.TssSelector;
-            sregs.Tr.Base = _exceptionTssPageGpa;
+            sregs.Tr.Base = vp.TssPageGpa;
             sregs.Tr.Limit = 0x67;
             sregs.Tr.Type = 11;
             sregs.Tr.S = 0;
@@ -1708,6 +1845,8 @@ namespace Brovan.Core.Emulation
         }
 
         public bool SupportsThreadResidency => _processorLimit > 1;
+
+        public int ProcessorLimit => _processorLimit;
 
         public bool IsThreadResident(uint threadId) => _threadProcessors.ContainsKey(threadId);
 
@@ -1753,9 +1892,8 @@ namespace Brovan.Core.Emulation
                 return;
 
             vp.ThreadId = 0;
+            vp.Binding++;
             _idleProcessors.Push(vp);
-            if (ReferenceEquals(_vp, vp))
-                _vp = _processors[0];
         }
 
         public void SelectThread(uint threadId)
@@ -1766,7 +1904,7 @@ namespace Brovan.Core.Emulation
                 LeaveSyscallStub(vp);
                 vp.ThreadId = threadId;
             }
-            _vp = vp;
+            SelectProcessor(vp);
         }
 
         private void InitializeSyscallTrapPage()
@@ -1814,10 +1952,6 @@ namespace Brovan.Core.Emulation
         {
             _exceptionStubPageGpa = AllocateInternalPage(true);
             _exceptionIdtPageGpa = AllocateInternalPage(false);
-            _exceptionTssPageGpa = AllocateInternalPage(false);
-
-            ulong exceptionStackSize = 16 * KvmConstants.PageSize;
-            _exceptionStackPageGpa = AllocateInternalRange(exceptionStackSize, KvmMemoryPermission.ReadWrite);
 
             unsafe
             {
@@ -1844,43 +1978,6 @@ namespace Brovan.Core.Emulation
                         Unsafe.WriteUnaligned(idt + vector * 16, low);
                         Unsafe.WriteUnaligned(idt + vector * 16 + 8, (uint)high);
                     }
-                }
-
-                if (_mappedPages.TryGetValue(_exceptionTssPageGpa, out MappedPage tssPage))
-                {
-                    byte* tss = (byte*)tssPage.HostPage;
-                    ulong stackTop = _exceptionStackPageGpa + exceptionStackSize;
-                    Unsafe.WriteUnaligned(tss + 0x04, stackTop);
-                    Unsafe.WriteUnaligned(tss + 0x24, stackTop);
-                    ushort ioMapBase = 0x68;
-                    Unsafe.WriteUnaligned(tss + 0x66, ioMapBase);
-                }
-            }
-
-            if (_gdtPageGpa != 0 && _mappedPages.TryGetValue(_gdtPageGpa, out MappedPage gdtMapped) && gdtMapped.HostPage != IntPtr.Zero)
-            {
-                unsafe
-                {
-                    byte* gdt = (byte*)gdtMapped.HostPage;
-                    int tssIndex = KvmConstants.TssSelector >> 3;
-                    ulong tssBase = _exceptionTssPageGpa;
-                    uint tssLimit = 0x67;
-                    gdt[tssIndex * 8 + 0] = (byte)(tssLimit & 0xFF);
-                    gdt[tssIndex * 8 + 1] = (byte)((tssLimit >> 8) & 0xFF);
-                    gdt[tssIndex * 8 + 2] = (byte)(tssBase & 0xFF);
-                    gdt[tssIndex * 8 + 3] = (byte)((tssBase >> 8) & 0xFF);
-                    gdt[tssIndex * 8 + 4] = (byte)((tssBase >> 16) & 0xFF);
-                    gdt[tssIndex * 8 + 5] = (byte)(0x89 | 0x80);
-                    gdt[tssIndex * 8 + 6] = (byte)(((tssLimit >> 16) & 0xF) | 0x00);
-                    gdt[tssIndex * 8 + 7] = (byte)((tssBase >> 24) & 0xFF);
-                    gdt[tssIndex * 8 + 8] = (byte)((tssBase >> 32) & 0xFF);
-                    gdt[tssIndex * 8 + 9] = (byte)((tssBase >> 40) & 0xFF);
-                    gdt[tssIndex * 8 + 10] = (byte)((tssBase >> 48) & 0xFF);
-                    gdt[tssIndex * 8 + 11] = (byte)((tssBase >> 56) & 0xFF);
-                    gdt[tssIndex * 8 + 12] = 0;
-                    gdt[tssIndex * 8 + 13] = 0;
-                    gdt[tssIndex * 8 + 14] = 0;
-                    gdt[tssIndex * 8 + 15] = 0;
                 }
             }
         }
@@ -2114,6 +2211,70 @@ namespace Brovan.Core.Emulation
             return index > 0 ? index - 1 : 0;
         }
 
+        // A slot whose pages still map as installed stays as it is. Replacing it unmaps it for a moment, and
+        // a processor delivering an exception in that moment cannot recover. Slots merge only when they run out.
+        private void MarkIntactSlots(ulong spanStart, ulong spanEnd)
+        {
+            _keptSlotStarts.Clear();
+            if (_activeSlots.Count + SlotHeadroom >= _maxMemslots) return;
+
+            int firstIndex = FirstActiveSlotIndexAtOrBefore(spanStart);
+            for (int i = firstIndex; i < _activeSlotStarts.Count; i++)
+            {
+                ulong start = _activeSlotStarts[i];
+                if (start >= spanEnd) break;
+
+                InstalledSlot active = _activeSlots[start];
+                if (start + active.Size <= spanStart) continue;
+                if (!IsSlotIntact(start, active)) continue;
+
+                _keptSlotStarts.Add(start);
+                _desiredSlots[start] = active;
+            }
+        }
+
+        private bool IsSlotIntact(ulong start, InstalledSlot slot)
+        {
+            bool anyTrapped = _trappedPages.Count != 0;
+            for (ulong off = 0; off < slot.Size; off += KvmConstants.PageSize)
+            {
+                ulong address = start + off;
+                if (!_mappedPages.TryGetValue(address, out MappedPage page)
+                    || page == null
+                    || page.HostPage == IntPtr.Zero
+                    || page.Permissions == KvmMemoryPermission.None)
+                    return false;
+                if (page.HostPage.ToInt64() != slot.Host.ToInt64() + (long)off) return false;
+
+                uint flags;
+                if (anyTrapped && _trappedPages.TryGetValue(address, out bool writeOnly))
+                {
+                    if (!writeOnly || slot.Size != KvmConstants.PageSize) return false;
+                    flags = KvmConstants.MemSlotReadOnly;
+                }
+                else
+                {
+                    flags = ToKvmMapFlags(page.Permissions);
+                }
+                if (flags != slot.Flags) return false;
+            }
+            return true;
+        }
+
+        private bool TryGetKeptSlotEnd(ulong address, out ulong end)
+        {
+            end = 0;
+            if (_keptSlotStarts.Count == 0 || _activeSlotStarts.Count == 0) return false;
+
+            ulong start = _activeSlotStarts[FirstActiveSlotIndexAtOrBefore(address)];
+            if (start > address || !_keptSlotStarts.Contains(start)) return false;
+
+            InstalledSlot slot = _activeSlots[start];
+            if (address - start >= slot.Size) return false;
+            end = start + slot.Size;
+            return true;
+        }
+
         private void RebuildMappingsFull()
         {
             ulong[] sortedKeys = GetSortedPageKeys();
@@ -2121,10 +2282,18 @@ namespace Brovan.Core.Emulation
             bool anyTrapped = _trappedPages.Count != 0;
 
             _desiredSlots.Clear();
+            MarkIntactSlots(0, ulong.MaxValue);
+            bool anyKept = _keptSlotStarts.Count != 0;
 
             for (int i = 0; i < keyCount;)
             {
                 ulong runAddress = sortedKeys[i];
+                if (TryGetKeptSlotEnd(runAddress, out ulong keptEnd))
+                {
+                    while (i < keyCount && sortedKeys[i] < keptEnd) i++;
+                    continue;
+                }
+
                 if (!_mappedPages.TryGetValue(runAddress, out MappedPage page)
                     || page == null
                     || page.HostPage == IntPtr.Zero
@@ -2150,6 +2319,7 @@ namespace Brovan.Core.Emulation
                 while (j < keyCount)
                 {
                     if (sortedKeys[j] != runAddress + runSize) break;
+                    if (anyKept && _keptSlotStarts.Contains(sortedKeys[j])) break;
                     if (!_mappedPages.TryGetValue(sortedKeys[j], out MappedPage next) || next == null) break;
                     if (next.Permissions != page.Permissions) break;
                     if (anyTrapped && _trappedPages.ContainsKey(sortedKeys[j])) break;
@@ -2195,12 +2365,8 @@ namespace Brovan.Core.Emulation
             _activeSlotStarts.Sort();
         }
 
-        // One page either side of the change, so a neighbouring slot can absorb it.
         private void RebuildMappingsIncremental(ulong spanStart, ulong spanEnd)
         {
-            if (spanStart >= KvmConstants.PageSize) spanStart -= KvmConstants.PageSize;
-            if (spanEnd <= ulong.MaxValue - KvmConstants.PageSize) spanEnd += KvmConstants.PageSize;
-
             int firstIndex = FirstActiveSlotIndexAtOrBefore(spanStart);
             for (int i = firstIndex; i < _activeSlotStarts.Count; i++)
             {
@@ -2216,6 +2382,7 @@ namespace Brovan.Core.Emulation
             }
 
             _desiredSlots.Clear();
+            MarkIntactSlots(spanStart, spanEnd);
             BuildDesiredSlotsForSpan(spanStart, spanEnd);
 
             _staleSlotKeys.Clear();
@@ -2252,9 +2419,16 @@ namespace Brovan.Core.Emulation
         private void BuildDesiredSlotsForSpan(ulong spanStart, ulong spanEnd)
         {
             bool anyTrapped = _trappedPages.Count != 0;
+            bool anyKept = _keptSlotStarts.Count != 0;
 
             for (ulong address = spanStart; address < spanEnd;)
             {
+                if (TryGetKeptSlotEnd(address, out ulong keptEnd))
+                {
+                    address = keptEnd;
+                    continue;
+                }
+
                 if (!_mappedPages.TryGetValue(address, out MappedPage page)
                     || page == null
                     || page.HostPage == IntPtr.Zero
@@ -2278,6 +2452,7 @@ namespace Brovan.Core.Emulation
 
                 while (address + runSize < spanEnd)
                 {
+                    if (anyKept && _keptSlotStarts.Contains(address + runSize)) break;
                     if (!_mappedPages.TryGetValue(address + runSize, out MappedPage next) || next == null) break;
                     if (next.Permissions != page.Permissions) break;
                     if (next.HostPage == IntPtr.Zero) break;
@@ -2390,12 +2565,9 @@ namespace Brovan.Core.Emulation
 
             if (opcode[0] != 0x0F) return false;
 
+            // rdtsc and rdtscp run on the processor, so they never reach here.
             if (_hasCpuIdHook && opcode[1] == 0xA2)
                 return HandleInstructionHook(BackendInstructionHook.CpuId, 2);
-            if (_hasRdtscHook && opcode[1] == 0x31)
-                return HandleInstructionHook(BackendInstructionHook.Rdtsc, 2);
-            if (_hasRdtscpHook && opcode[1] == 0x01 && opcode[2] == 0xF9)
-                return HandleInstructionHook(BackendInstructionHook.Rdtscp, 3);
             if (_hasInvalidHook && opcode[1] == 0x0B)
                 return HandleInvalidInstructionHook();
             return false;
@@ -2404,8 +2576,6 @@ namespace Brovan.Core.Emulation
         private void RefreshInstructionHookFlags()
         {
             _hasCpuIdHook = false;
-            _hasRdtscHook = false;
-            _hasRdtscpHook = false;
             _hasInvalidHook = false;
 
             for (int i = 0; i < _instructionHooks.Count; i++)
@@ -2413,13 +2583,11 @@ namespace Brovan.Core.Emulation
                 switch (_instructionHooks[i].Type)
                 {
                     case BackendInstructionHook.CpuId: _hasCpuIdHook = true; break;
-                    case BackendInstructionHook.Rdtsc: _hasRdtscHook = true; break;
-                    case BackendInstructionHook.Rdtscp: _hasRdtscpHook = true; break;
                     case BackendInstructionHook.Invalid: _hasInvalidHook = true; break;
                 }
             }
 
-            _scanPreRunInstructions = _hasCpuIdHook || _hasRdtscHook || _hasRdtscpHook || _hasInvalidHook;
+            _scanPreRunInstructions = _hasCpuIdHook || _hasInvalidHook;
         }
 
         private unsafe bool TryReadMemoryInternal(ulong address, Span<byte> buffer)
@@ -2525,7 +2693,7 @@ namespace Brovan.Core.Emulation
             return consumed;
         }
 
-        private bool HandleHltExit()
+        private bool HandleHltExit(VirtualProcessor vp)
         {
             ulong rip = ReadRegister(Registers.UC_X86_REG_RIP);
 
@@ -2540,10 +2708,10 @@ namespace Brovan.Core.Emulation
                 KvmConstants.ExceptionVectorCount * KvmConstants.ExceptionStubStride;
             if (rip > _exceptionStubPageGpa && rip <= stubEnd)
             {
-                if (_singleStepRequested &&
+                if (vp.SingleStepRequested &&
                     (uint)((rip - 1 - _exceptionStubPageGpa) / KvmConstants.ExceptionStubStride) == 1)
                 {
-                    _singleStepRequested = false;
+                    vp.SingleStepRequested = false;
                     RestoreExceptionFrame(rip);
                     ClearTrapFlag();
                     _error = KvmErrors.Ok;
@@ -2561,7 +2729,7 @@ namespace Brovan.Core.Emulation
             return false;
         }
 
-        private unsafe bool HandleMmioExit(ref LinuxKvmRun run)
+        private unsafe bool HandleMmioExit(VirtualProcessor vp, ref LinuxKvmRun run)
         {
             ref LinuxKvmMmioExit mmio = ref run.Exit.Mmio;
             ulong physAddr = mmio.PhysAddr;
@@ -2569,9 +2737,9 @@ namespace Brovan.Core.Emulation
             byte isWrite = mmio.IsWrite;
 
             // A later fragment of the faulted instruction.
-            if (_faultRegistersSaved)
+            if (vp.FaultRegistersSaved)
             {
-                _mmioCompletionPending = true;
+                vp.MmioCompletionPending = true;
                 return true;
             }
 
@@ -2637,9 +2805,9 @@ namespace Brovan.Core.Emulation
             {
                 // The completion writes back RIP and the loaded register. The fault-time registers go back
                 // after it.
-                _faultRegisters = GetRegisters();
-                _faultRegistersSaved = true;
-                _mmioCompletionPending = true;
+                vp.FaultRegisters = GetRegisters();
+                vp.FaultRegistersSaved = true;
+                vp.MmioCompletionPending = true;
                 return false;
             }
 
@@ -2689,7 +2857,7 @@ namespace Brovan.Core.Emulation
         private unsafe void CompleteMmioAccess(ref LinuxKvmMmioExit mmio)
         {
             // KVM retires the instruction on its next entry, before it reads immediate_exit.
-            _mmioCompletionPending = true;
+            CurrentVp.MmioCompletionPending = true;
 
             uint len = mmio.Len;
             if (len == 0 || len > sizeof(ulong)) return;
@@ -2810,7 +2978,7 @@ namespace Brovan.Core.Emulation
             lock (_vcpuLock)
             {
                 LinuxKvmVcpuEvents events = new LinuxKvmVcpuEvents();
-                if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoGetVcpuEvents, ref events) < 0)
+                if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoGetVcpuEvents, ref events) < 0)
                     return;
 
                 events.Exception.Injected = 0;
@@ -2824,7 +2992,7 @@ namespace Brovan.Core.Emulation
                 events.Nmi.Injected = 0;
                 events.Nmi.Pending = 0;
 
-                if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoSetVcpuEvents, ref events) < 0)
+                if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoSetVcpuEvents, ref events) < 0)
                     return;
             }
         }
@@ -2855,7 +3023,7 @@ namespace Brovan.Core.Emulation
             regs.Rflags = savedRflags;
             MarkRegistersDirty();
             ShowUserCodeAndStackSegments();
-            _vp.InSyscallStub = true;
+            CurrentVp.InSyscallStub = true;
 
             if (_syscallHook.Callback != null) _syscallHook.Callback();
             else if (_syscallHook.BoolCallback != null) _syscallHook.BoolCallback();
@@ -2881,7 +3049,7 @@ namespace Brovan.Core.Emulation
         private void NoteSyscallScratchWrite(GpRegisterName name, ulong before, ulong after)
         {
             if (before != after && (name == GpRegisterName.Rcx || name == GpRegisterName.R11))
-                LeaveSyscallStub(_vp);
+                LeaveSyscallStub(CurrentVp);
         }
 
         private static void LeaveSyscallStub(VirtualProcessor vp)
@@ -2894,7 +3062,7 @@ namespace Brovan.Core.Emulation
         // sysretq takes RIP from RCX and RFLAGS from R11, which is what NT leaves in them.
         private void PrepareSyscallReturn(VirtualProcessor vp, ref LinuxKvmRun run)
         {
-            if (_singleStepRequested)
+            if (vp.SingleStepRequested)
                 run.DirtyRegs |= KvmConstants.SyncSpecialRegisters;
 
             if ((run.DirtyRegs & KvmConstants.SyncSpecialRegisters) != 0)
@@ -2930,6 +3098,34 @@ namespace Brovan.Core.Emulation
         {
             GetRegistersRef().Rip += amount;
             MarkRegistersDirty();
+        }
+
+        // KVM starts every new vCPU TSC at zero, while the guest and the shared QPC page take one TSC for the
+        // whole partition. Later vCPUs get the offset of the first.
+        private unsafe void AlignTimestampCounter(VirtualProcessor vp)
+        {
+            if (!_supportsVcpuAttributes)
+                return;
+
+            ulong value = 0;
+            LinuxKvmDeviceAttr attr = new LinuxKvmDeviceAttr
+            {
+                Group = KvmConstants.VcpuTscCtrl,
+                Attr = KvmConstants.VcpuTscOffset,
+                Addr = (ulong)&value,
+            };
+
+            if (!_tscOffsetKnown)
+            {
+                if (KvmNative.ioctl(vp.Fd, KvmConstants.KvmIoGetDeviceAttr, ref attr) < 0)
+                    return;
+                _tscOffset = value;
+                _tscOffsetKnown = true;
+                return;
+            }
+
+            value = _tscOffset;
+            KvmNative.ioctl(vp.Fd, KvmConstants.KvmIoSetDeviceAttr, ref attr);
         }
 
         private ulong GetMsr(VirtualProcessor vp, uint msr)
@@ -2969,7 +3165,7 @@ namespace Brovan.Core.Emulation
         {
             ref LinuxKvmRegisters current = ref GetRegistersRef();
             if (regs.Rcx != current.Rcx || regs.R11 != current.R11)
-                LeaveSyscallStub(_vp);
+                LeaveSyscallStub(CurrentVp);
             current = regs;
             MarkRegistersDirty();
         }
@@ -3002,7 +3198,7 @@ namespace Brovan.Core.Emulation
 
             lock (_vcpuLock)
             {
-                if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoGetFpu, (IntPtr)(&Fpu)) < 0)
+                if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoGetFpu, (IntPtr)(&Fpu)) < 0)
                     return false;
 
                 if (Write)
@@ -3010,7 +3206,7 @@ namespace Brovan.Core.Emulation
                     for (int i = 0; i < XmmRegisterCount * 2; i++)
                         ((ulong*)Fpu.Xmm)[i] = Values[i];
 
-                    if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoSetFpu, (IntPtr)(&Fpu)) < 0)
+                    if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoSetFpu, (IntPtr)(&Fpu)) < 0)
                         return false;
                 }
                 else
@@ -3039,7 +3235,7 @@ namespace Brovan.Core.Emulation
         {
             lock (_vcpuLock)
             {
-                if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoSetVcpuEvents, ref events) < 0)
+                if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoSetVcpuEvents, ref events) < 0)
                     throw new KvmException("KVM_SET_VCPU_EVENTS failed", Marshal.GetLastWin32Error());
             }
         }
@@ -3049,7 +3245,7 @@ namespace Brovan.Core.Emulation
             lock (_vcpuLock)
             {
                 LinuxKvmDebugRegisters dr = new LinuxKvmDebugRegisters();
-                if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoGetDebugRegisters, ref dr) < 0)
+                if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoGetDebugRegisters, ref dr) < 0)
                     throw new KvmException("KVM_GET_DEBUGREGS failed", Marshal.GetLastWin32Error());
                 return dr;
             }
@@ -3059,7 +3255,7 @@ namespace Brovan.Core.Emulation
         {
             lock (_vcpuLock)
             {
-                if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoSetDebugRegisters, ref dr) < 0)
+                if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoSetDebugRegisters, ref dr) < 0)
                     throw new KvmException("KVM_SET_DEBUGREGS failed", Marshal.GetLastWin32Error());
             }
         }
@@ -3137,7 +3333,7 @@ namespace Brovan.Core.Emulation
 
             lock (_vcpuLock)
             {
-                if (KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoGetFpu, (IntPtr)(&Fpu)) < 0)
+                if (KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoGetFpu, (IntPtr)(&Fpu)) < 0)
                     return false;
 
                 if (!Write)
@@ -3151,7 +3347,7 @@ namespace Brovan.Core.Emulation
                 else
                     Fpu.Mxcsr = (uint)value;
 
-                return KvmNative.ioctl(_vp.Fd, KvmConstants.KvmIoSetFpu, (IntPtr)(&Fpu)) >= 0;
+                return KvmNative.ioctl(CurrentVp.Fd, KvmConstants.KvmIoSetFpu, (IntPtr)(&Fpu)) >= 0;
             }
         }
 

--- a/Brovan/Core/Emulation/KvmBinding/Native.cs
+++ b/Brovan/Core/Emulation/KvmBinding/Native.cs
@@ -41,6 +41,9 @@ namespace Brovan.Core.Emulation
         public static extern int ioctl(int fd, uint request, ref LinuxKvmMsrs arg);
 
         [DllImport("libc", SetLastError = true)]
+        public static extern int ioctl(int fd, uint request, ref LinuxKvmDeviceAttr arg);
+
+        [DllImport("libc", SetLastError = true)]
         public static extern int ioctl(int fd, uint request, ref LinuxKvmVcpuEvents arg);
 
         [DllImport("libc", SetLastError = true)]
@@ -202,6 +205,15 @@ namespace Brovan.Core.Emulation
         public uint Count;
         public uint _pad0;
         public LinuxKvmMsrEntry FirstEntry;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct LinuxKvmDeviceAttr
+    {
+        public uint Flags;
+        public uint Group;
+        public ulong Attr;
+        public ulong Addr;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/Brovan/Core/Emulation/OS/Linux/LinuxSyscallsHelper.cs
+++ b/Brovan/Core/Emulation/OS/Linux/LinuxSyscallsHelper.cs
@@ -1909,12 +1909,28 @@ namespace Brovan.Core.Emulation.OS.Linux
 
         public ulong ProgramBreak { get; set; }
         public ulong ProgramBreakBase { get; set; }
-        public bool CpuidEnabled { get; set; }
+        public bool CpuidEnabled
+        {
+            get => CurrentThreadState?.CpuidEnabled ?? true;
+            set
+            {
+                EmulatedThread Thread = Emulator?.CurrentThread;
+                if (Thread == null)
+                    return;
+
+                if (Thread.GuestState is not LinuxThreadState State)
+                    Thread.GuestState = State = new LinuxThreadState();
+
+                State.CpuidEnabled = value;
+            }
+        }
         public int PID { get; private set; }
         public int ParentPid { get; private set; }
         public int ProcessGroupId { get; private set; }
         public int SessionId { get; private set; }
-        public int CurrentThreadId { get; set; }
+        internal BinaryEmulator Emulator { get; set; }
+        public int CurrentThreadId => Emulator != null && Emulator.CurrentThreadId > 0 ? Emulator.CurrentThreadId : 0;
+        private LinuxThreadState CurrentThreadState => Emulator?.CurrentThread?.GuestState as LinuxThreadState;
         public byte[] AuxiliaryVector { get; set; } = Array.Empty<byte>();
         public Dictionary<int, LinuxResourceLimit> ResourceLimits { get; private set; }
         public FileDescriptorTable DescriptorTable { get; private set; }
@@ -1950,7 +1966,6 @@ namespace Brovan.Core.Emulation.OS.Linux
             ParentPid = 273;
             ProcessGroupId = 273;
             SessionId = 273;
-            CpuidEnabled = true;
             RealtimeClockBaseUtc = DateTimeOffset.UtcNow;
             MonotonicClock = Stopwatch.StartNew();
             SyntheticUptimeBase = TimeSpan.FromSeconds(RandomNumberGenerator.GetInt32(MinimumSyntheticUptimeSeconds, MaximumSyntheticUptimeSeconds + 1));
@@ -2195,7 +2210,6 @@ namespace Brovan.Core.Emulation.OS.Linux
                 return;
 
             SyncCurrentProcessMetadata();
-            CurrentThreadId = (int)Thread.ThreadId;
 
             if (!CurrentProcess.Threads.TryGetValue(Thread.ThreadId, out LinuxTaskInfo Task))
             {
@@ -2218,8 +2232,6 @@ namespace Brovan.Core.Emulation.OS.Linux
                 return;
 
             CurrentProcess.Threads.Remove(ThreadId);
-            if (CurrentThreadId == (int)ThreadId)
-                CurrentThreadId = 0;
         }
 
         public bool TryGetThreadInfo(uint ThreadId, out LinuxTaskInfo Task)

--- a/Brovan/Core/Emulation/OS/Linux/Process/clone.cs
+++ b/Brovan/Core/Emulation/OS/Linux/Process/clone.cs
@@ -113,7 +113,6 @@ namespace Brovan.Core.Emulation.OS.Linux.Process
             };
 
             Helper.RegisterThread(Child);
-            Helper.CurrentThreadId = (int)Parent.ThreadId;
             Instance.Threads[ThreadId] = Child;
             Instance.ThreadOrder.Add((int)ThreadId);
             Helper.SetReturnValue(Instance, Context, ThreadId);

--- a/Brovan/Core/Emulation/OS/Windows/BinaryEmulator.WindowsBridge.cs
+++ b/Brovan/Core/Emulation/OS/Windows/BinaryEmulator.WindowsBridge.cs
@@ -71,7 +71,7 @@ namespace Brovan.Core.Emulation
 
         public ulong KUSER_SHARED_DATA = 0x7FFE0000;
 
-        internal bool SuppressSyscallStatusWrite = false;
+        internal bool SuppressSyscallStatusWrite { get => Worker.SuppressStatusWrite; set => Worker.SuppressStatusWrite = value; }
 
         public ulong ProcessCookie = 0;
 

--- a/Brovan/Core/Emulation/OS/Windows/Files/NtLockFile.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Files/NtLockFile.cs
@@ -1,11 +1,12 @@
 using System;
-using System.Threading;
 using static Brovan.Core.Helpers.BinaryHelpers;
 
 namespace Brovan.Core.Emulation.OS.Windows
 {
     internal sealed class NtLockFile : IWinSyscall
     {
+        private const int LockRetrySliceMilliseconds = 1;
+
         public NTSTATUS Handle(BinaryEmulator Instance)
         {
 
@@ -55,20 +56,14 @@ namespace Brovan.Core.Emulation.OS.Windows
                 return RangeStatus;
             }
 
-            while (true)
+            if (FileObj.GetConflictingLock(Offset, Length, Key, ExclusiveLock) != null)
             {
-                WinFile.WinLockFile Conflict = FileObj.GetConflictingLock(Offset, Length, Key, ExclusiveLock);
-                if (Conflict == null)
-                    break;
+                if (!FailImmediately && Instance.WinHelper.TryRetrySyscallAfterSlice(LockRetrySliceMilliseconds))
+                    return NTSTATUS.STATUS_PENDING;
 
-                if (FailImmediately)
-                {
-                    Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlockPtr, NTSTATUS.STATUS_LOCK_NOT_GRANTED, 0);
-                    SignalEvent(Instance, EventHandle, NTSTATUS.STATUS_LOCK_NOT_GRANTED);
-                    return NTSTATUS.STATUS_LOCK_NOT_GRANTED;
-                }
-
-                Thread.Sleep(1);
+                Instance.WinHelper.WriteIoStatusBlock(Instance, IoStatusBlockPtr, NTSTATUS.STATUS_LOCK_NOT_GRANTED, 0);
+                SignalEvent(Instance, EventHandle, NTSTATUS.STATUS_LOCK_NOT_GRANTED);
+                return NTSTATUS.STATUS_LOCK_NOT_GRANTED;
             }
 
             FileObj.AddLock(Offset, Length, Key, ExclusiveLock);

--- a/Brovan/Core/Emulation/OS/Windows/Misc/NtRaiseException.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Misc/NtRaiseException.cs
@@ -118,7 +118,7 @@ namespace Brovan.Core.Emulation.OS.Windows
                     Instance.WinHelper.ClearTerminationState(CurrentThread);
                     CurrentThread.State = EmulatedThreadState.Terminated;
                     CurrentThread.ExitCode = unchecked((int)ExceptionCode);
-                    Instance.Threads[(uint)Instance.CurrentThreadId] = CurrentThread;
+                    Instance.WinHelper.ReleaseThreadResources(CurrentThread);
                     Instance._emulator.StopEmulation();
                     return NTSTATUS.STATUS_SUCCESS;
                 }

--- a/Brovan/Core/Emulation/OS/Windows/Process/GuestProcessLauncher.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/GuestProcessLauncher.cs
@@ -296,6 +296,11 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Instance.Settings.NoHooks)
                 Arguments.Add("--no-hooks");
 
+            if (!Instance.Settings.Smp)
+                Arguments.Add("--no-smp");
+            else if (Instance.Settings.SmpWorkers > 0)
+                Arguments.Add($"--cores={Instance.Settings.SmpWorkers}");
+
             if (!UnicornCodeCache.Enabled)
                 Arguments.Add("--no-jit-cache");
             else if (!string.IsNullOrEmpty(UnicornCodeCache.CacheDirectory))

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtGetContextThread.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtGetContextThread.cs
@@ -21,6 +21,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Status != NTSTATUS.STATUS_SUCCESS)
                 return Status;
 
+            if (!Instance.WaitUntilParked(Thread))
+                return NTSTATUS.STATUS_UNSUCCESSFUL;
+
             WindowsThreadContext64.WriteContext(Instance, Thread, ContextPtr, Flags);
             return NTSTATUS.STATUS_SUCCESS;
         }

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtQueueApcThread.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtQueueApcThread.cs
@@ -43,7 +43,15 @@ namespace Brovan.Core.Emulation.OS.Windows
                 Thread.State = EmulatedThreadState.Ready;
 
             if (SpecialApc || AlertableWait)
-                Instance._emulator.StopEmulation();
+            {
+                if (Instance.CurrentThreadId == (int)Thread.ThreadId)
+                    Instance._emulator.StopEmulation();
+                else
+                {
+                    Instance._emulator.StopThread(Thread.ThreadId);
+                    Instance.YieldSliceAfterWake(Thread);
+                }
+            }
 
             return NTSTATUS.STATUS_SUCCESS;
         }

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtSetContextThread.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtSetContextThread.cs
@@ -21,6 +21,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (Status != NTSTATUS.STATUS_SUCCESS)
                 return Status;
 
+            if (!Instance.WaitUntilParked(Thread))
+                return NTSTATUS.STATUS_UNSUCCESSFUL;
+
             WindowsThreadContext64.ApplyContext(Instance, Thread, ContextPtr, Flags);
             return NTSTATUS.STATUS_SUCCESS;
         }

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtSuspendThread.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtSuspendThread.cs
@@ -37,6 +37,10 @@ namespace Brovan.Core.Emulation.OS.Windows
                 Instance._emulator.WriteRegister(Instance.IPRegister, NextRip);
                 Instance._emulator.StopEmulation();
             }
+            else
+            {
+                Instance._emulator.StopThread(TargetThread.ThreadId);
+            }
 
             return NTSTATUS.STATUS_SUCCESS;
         }

--- a/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateThread.cs
+++ b/Brovan/Core/Emulation/OS/Windows/Process/NtTerminateThread.cs
@@ -23,14 +23,19 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (TerminatingSelfByNullHandle && CountLiveThreads(Instance) <= 1)
                 return NTSTATUS.STATUS_CANT_TERMINATE_SELF;
 
+            bool TerminatingSelf = Instance.CurrentThread != null && TargetThread.ThreadId == (uint)Instance.CurrentThreadId;
+            if (!TerminatingSelf)
+                Instance.WaitUntilParked(TargetThread);
+
             Instance.WinHelper.AbandonMutexesOwnedByThread(TargetThread.ThreadId);
 
             TargetThread.ExitCode = unchecked((int)(uint)ExitStatus);
             Instance.WinHelper.ClearTerminationState(TargetThread);
             TargetThread.State = EmulatedThreadState.Terminated;
+            Instance.WinHelper.ReleaseThreadResources(TargetThread);
             Instance.WakeSignal.Bump();
 
-            if (Instance.CurrentThread != null && TargetThread.ThreadId == (uint)Instance.CurrentThreadId)
+            if (TerminatingSelf)
             {
                 Instance._emulator.WriteRegister(Instance.IPRegister, 0UL);
                 Instance._emulator.StopEmulation();

--- a/Brovan/Core/Emulation/OS/Windows/WinInternalHelper.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinInternalHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Brovan.Core.Helpers;
 using static Brovan.Core.Helpers.BinaryHelpers;
@@ -240,6 +241,20 @@ namespace Brovan.Core.Emulation.OS.Windows
             return ObjectIdToHandles.TryGetValue(ObjectId, out List<ulong> Handles) ? Handles.Count : 0;
         }
 
+        public bool HasHandleToObject(IHandleObject Object)
+        {
+            if (Object == null || !ObjectIdToHandles.TryGetValue(Object.ObjectId, out List<ulong> Handles))
+                return false;
+
+            for (int Index = 0; Index < Handles.Count; Index++)
+            {
+                if (HandleTable.TryGetValue(Handles[Index], out HandleEntry Entry) && ReferenceEquals(Entry.Object, Object))
+                    return true;
+            }
+
+            return false;
+        }
+
         public T? GetObjectByObjectId<T>(string ObjectId) where T : class, IHandleObject
         {
             if (!ObjectIdToHandles.TryGetValue(ObjectId, out List<ulong> Handles))
@@ -416,6 +431,7 @@ namespace Brovan.Core.Emulation.OS.Windows
         // A skew jump moves the anchor; drift between two host clocks stays below this and would only show
         // to the guest as a backward step.
         private const long SharedPageReanchorTicks = 1000;
+        private const long SharedPageBackwardTicks = 100000;
 
         private ulong _sharedPageScale;
         private ulong _sharedPageOffset;
@@ -448,12 +464,17 @@ namespace Brovan.Core.Emulation.OS.Windows
             ulong Scaled = (ulong)(((UInt128)Counter * SharedPageScale) >> 64);
             ulong Offset = Emulator.GetEmulatedPerformanceCounter() - Scaled;
             long Delta = unchecked((long)(Offset - _sharedPageOffset));
-            if (_sharedPageAnchored && Delta > -SharedPageReanchorTicks && Delta < SharedPageReanchorTicks)
+
+            // A smaller offset steps a reader on another processor backwards, so it takes a much wider
+            // miss to be worth publishing.
+            if (_sharedPageAnchored && Delta < SharedPageReanchorTicks && Delta > -SharedPageBackwardTicks)
                 return;
 
             _sharedPageOffset = Offset;
             _sharedPageAnchored = true;
             _sharedPageSequence = _sharedPageSequence == uint.MaxValue ? 1 : _sharedPageSequence + 1;
+
+            // The offset store lands before the sequence that publishes it.
             Emulator._emulator.WriteMemory(HypervisorSharedPage + OffsetSharedPageOffset, Offset, 8);
             Emulator._emulator.WriteMemory(HypervisorSharedPage + OffsetSharedPageSequence, _sharedPageSequence, 4);
         }
@@ -597,9 +618,10 @@ namespace Brovan.Core.Emulation.OS.Windows
             uint Low = (uint)(Value & 0xFFFFFFFF);
             uint High = (uint)(Value >> 32);
 
-            BitConverter.TryWriteBytes(Page.Slice(Offset, 4), Low);
-            BitConverter.TryWriteBytes(Page.Slice(Offset + 4, 4), High);
+            // NT: a reader retries while High1Time differs from High2Time, so High2Time lands first.
             BitConverter.TryWriteBytes(Page.Slice(Offset + 8, 4), High);
+            BitConverter.TryWriteBytes(Page.Slice(Offset, 4), Low);
+            Volatile.Write(ref MemoryMarshal.AsRef<uint>(Page.Slice(Offset + 4, 4)), High);
         }
 
         private int GetSystemCallOffset()
@@ -777,11 +799,10 @@ namespace Brovan.Core.Emulation.OS.Windows
             uint Low = (uint)(Value & 0xFFFFFFFF);
             uint High = (uint)(Value >> 32);
 
-            Span<byte> Tmp = stackalloc byte[12];
-            BitConverter.TryWriteBytes(Tmp.Slice(0, 4), Low);
-            BitConverter.TryWriteBytes(Tmp.Slice(4, 4), High);
-            BitConverter.TryWriteBytes(Tmp.Slice(8, 4), High);
-            Emulator._emulator.WriteMemory(Emulator.KUSER_SHARED_DATA + (ulong)Offset, Tmp);
+            ulong Address = Emulator.KUSER_SHARED_DATA + (ulong)Offset;
+            Emulator._emulator.WriteMemory(Address + 8, High, 4);
+            Emulator._emulator.WriteMemory(Address, Low, 4);
+            Emulator._emulator.WriteMemory(Address + 4, High, 4);
         }
     }
 
@@ -827,6 +848,9 @@ namespace Brovan.Core.Emulation.OS.Windows
         private int DelayEdges;
 
         private long LastPumpTicks;
+        private ulong ListHead;
+        private ulong LastHeadFlink;
+        private ulong LastHeadBlink;
 
         private readonly Dictionary<ulong, ModuleInfo> LastSnapshot = new Dictionary<ulong, ModuleInfo>();
 
@@ -896,7 +920,36 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (!PollDriven)
                 return;
 
+            PollListHead();
             Drain();
+        }
+
+        // Every load and unload touches the list head. Reading it costs less than a write watch on the page
+        // it shares with the loader lock.
+        private void PollListHead()
+        {
+            if (ListHead == 0)
+            {
+                ulong LdrData = SafeReadPointer(Emulator.PEB + (ulong)PebOffsetLdr);
+                if (LdrData == 0 || !Emulator.IsRegionMapped(LdrData, (uint)PebLdrSize))
+                    return;
+                ListHead = LdrData + (ulong)PebLdrOffsetInLoadOrder;
+                if (!Emulator.IsRegionMapped(ListHead, (uint)(PointerSize * 2)))
+                {
+                    ListHead = 0;
+                    return;
+                }
+            }
+
+            if (!TryReadHeadLinks(out ulong Flink, out ulong Blink))
+                return;
+            if (Flink == LastHeadFlink && Blink == LastHeadBlink)
+                return;
+
+            LastHeadFlink = Flink;
+            LastHeadBlink = Blink;
+            PendingSync = true;
+            DelayEdges = 2;
         }
 
         private void Drain()
@@ -976,7 +1029,8 @@ namespace Brovan.Core.Emulation.OS.Windows
             if (PendingRefreshHooks)
             {
                 PendingRefreshHooks = false;
-                RefreshLdrHooks();
+                if (!PollDriven)
+                    RefreshLdrHooks();
             }
 
             if (!PendingSync)
@@ -1179,6 +1233,35 @@ namespace Brovan.Core.Emulation.OS.Windows
             {
                 return false;
             }
+        }
+
+        // PEB_LDR_DATA stays mapped for the life of the process, so the range check made when the head was
+        // resolved still holds.
+        private bool TryReadHeadLinks(out ulong Flink, out ulong Blink)
+        {
+            Flink = 0;
+            Blink = 0;
+
+            Span<byte> Links = stackalloc byte[16];
+            try
+            {
+                Emulator.ReadMemory(ListHead, Links.Slice(0, PointerSize * 2));
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (PointerSize == 8)
+            {
+                Flink = BitConverter.ToUInt64(Links.Slice(0, 8));
+                Blink = BitConverter.ToUInt64(Links.Slice(8, 8));
+                return true;
+            }
+
+            Flink = BitConverter.ToUInt32(Links.Slice(0, 4));
+            Blink = BitConverter.ToUInt32(Links.Slice(4, 4));
+            return true;
         }
 
         private ulong SafeReadPointer(ulong address)

--- a/Brovan/Core/Emulation/OS/Windows/WinInternalHelper.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinInternalHelper.cs
@@ -802,6 +802,9 @@ namespace Brovan.Core.Emulation.OS.Windows
             ulong Address = Emulator.KUSER_SHARED_DATA + (ulong)Offset;
             Emulator._emulator.WriteMemory(Address + 8, High, 4);
             Emulator._emulator.WriteMemory(Address, Low, 4);
+
+            // NT: a reader retries while High1Time differs from High2Time, so High1Time lands last.
+            Interlocked.MemoryBarrier();
             Emulator._emulator.WriteMemory(Address + 4, High, 4);
         }
     }

--- a/Brovan/Core/Emulation/OS/Windows/WinSyscallsHelper.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinSyscallsHelper.cs
@@ -331,6 +331,59 @@ namespace Brovan.Core.Emulation.OS.Windows
             }
         }
 
+        // NT frees the TEB and the initial stack when a thread ends, and keeps the thread object while a
+        // handle refers to it. A thread still on a processor is released by its worker at the end of the slice.
+        public void ReleaseThreadResources(EmulatedThread Thread)
+        {
+            if (Thread == null || Thread.State != EmulatedThreadState.Terminated)
+                return;
+
+            bool Current = Emulator.CurrentThreadId == (int)Thread.ThreadId;
+            if (!Current && Thread.HostWorker != -1)
+                return;
+
+            if (!Current)
+                Emulator.ReleaseThreadProcessor(Thread);
+
+            if (Thread.StackAddress != 0)
+            {
+                if (!Emulator.ReleaseMemory(Thread.StackAddress))
+                    Emulator.UnmapMemoryRegion(Thread.StackAddress);
+                Thread.StackAddress = 0;
+            }
+
+            WindowsThreadState State = WinEmulatedThread.TryGetState(Thread);
+            if (State != null)
+            {
+                ulong TebBase = State.NativeTeb != 0 ? State.NativeTeb : State.Teb;
+                if (TebBase != 0)
+                    Emulator.UnmapMemoryRegion(TebBase);
+                State.Teb = 0;
+                State.NativeTeb = 0;
+
+                if (State.InitialContext != 0)
+                {
+                    Emulator.UnmapMemoryRegion(State.InitialContext);
+                    State.InitialContext = 0;
+                }
+            }
+
+            ForgetThreadIfUnreferenced(Thread);
+        }
+
+        public void ForgetThreadIfUnreferenced(EmulatedThread Thread)
+        {
+            if (Thread == null || Thread.State != EmulatedThreadState.Terminated || HandleManager.HasHandleToObject(Thread))
+                return;
+
+            Thread.Unreferenced = true;
+            if (Thread.HostWorker != -1 || Emulator.CurrentThreadId == (int)Thread.ThreadId)
+                return;
+
+            Emulator.ReleaseThreadProcessor(Thread);
+            Emulator.Threads.Remove(Thread.ThreadId);
+        }
+
         /// <summary>
         /// Clears wait, worker-factory, and exception state for a thread that is exiting.
         /// </summary>
@@ -7750,6 +7803,10 @@ namespace Brovan.Core.Emulation.OS.Windows
 
                 case WinMutex Mutex:
                     WinMutexes.Remove(Mutex);
+                    break;
+
+                case EmulatedThread Thread:
+                    ForgetThreadIfUnreferenced(Thread);
                     break;
             }
         }

--- a/Brovan/Core/Emulation/OS/Windows/WinThreading.cs
+++ b/Brovan/Core/Emulation/OS/Windows/WinThreading.cs
@@ -23,6 +23,7 @@ namespace Brovan.Core.Emulation.OS.Windows
 
         // The 64-bit TEB a WOW64 thread also owns. SysWOW64 modules reach it through WowTebOffset and use x64 offsets in it.
         public ulong NativeTeb { get; set; }
+        public ulong InitialContext { get; set; }
         public WinToken ImpersonationToken { get; set; }
         public ulong ExceptionFunc { get; set; }
         public bool ApcAlertable { get; set; }

--- a/Brovan/Core/Emulation/RuntimeTypes.cs
+++ b/Brovan/Core/Emulation/RuntimeTypes.cs
@@ -68,6 +68,10 @@ namespace Brovan.Core.Emulation
         public bool DisablePriorityBoost;
         public long LastReadyTick;
         public long LastRunTick = -1;
+        public int HostWorker = -1;
+        public bool ParkWaiting;
+        public EmulatedThread ParkTarget;
+        public bool Unreferenced;
 
         public int EffectivePriority
         {

--- a/Brovan/Core/Emulation/WhpBinding/Whp.cs
+++ b/Brovan/Core/Emulation/WhpBinding/Whp.cs
@@ -29,7 +29,7 @@ namespace Brovan.Core.Emulation
         private IntPtr _partition = IntPtr.Zero;
         private const uint SharedVpIndex = 0;
         private const uint MaxVirtualProcessors = 240;
-        private IntPtr _exitContextPtr = IntPtr.Zero;
+        private const ulong ExceptionStackPages = 2;
 
         private readonly Dictionary<ulong, MappedPage> _mappedPages = new();
         private readonly Dictionary<IntPtr, BackingAllocation> _backingAllocations = new();
@@ -48,6 +48,11 @@ namespace Brovan.Core.Emulation
         private readonly List<ulong> _staleMapKeys = new();
 
         private readonly List<ulong> _activeMapStarts = new();
+        private readonly HashSet<ulong> _keptMapStarts = new();
+
+        // Kept maps never merge, so past this count the next rebuild merges everything and starts over.
+        private const int MaxGpaRanges = 8192;
+        private const int MapHeadroom = 64;
         private bool _fullRebuildRequired = true;
         private readonly List<DirtyRange> _dirtyRanges = new();
         private const int MaxDirtyRanges = 16;
@@ -64,16 +69,18 @@ namespace Brovan.Core.Emulation
         private ulong _syscallTrapPageGpa;
         private ulong _exceptionStubPageGpa;
         private ulong _exceptionIdtPageGpa;
-        private ulong _exceptionTssPageGpa;
-        private ulong _exceptionStackPageGpa;
         private ulong _gdtPageGpa;
 
         private readonly object _vcpuLock = new();
 
         private sealed class VirtualProcessor
         {
+            public Whp Owner;
             public uint Index;
             public uint ThreadId;
+            public IntPtr ExitContextPtr;
+            public ulong GdtPageGpa;
+            public ulong TssPageGpa;
             public WhpRegisters Regs;
             public bool RegsValid;
             public bool RegsDirty;
@@ -85,16 +92,55 @@ namespace Brovan.Core.Emulation
             public bool SegmentsDirty;
             public ulong FsBase = ulong.MaxValue;
             public ulong GsBase = ulong.MaxValue;
+
+            public bool CompletionActive;
+            public ulong CompletionPageGpa;
+            public ulong CompletionAccessGpa;
+            public uint CompletionLen;
+            public bool CompletionIsWrite;
+
+            public volatile bool StopRequested;
+            public volatile bool Running;
+            public int HostThreadId;
+            public bool SingleStepRequested;
+            public long SliceDeadlineTimestamp;
+            public long SliceGeneration;
+            public long SliceExpiredGeneration;
+
+            // Bumped when the VP leaves a guest thread. A selection made before the bump is stale.
+            public long Binding;
         }
 
-        // Each guest thread runs on its own VP so a thread switch moves no register state. Threads past
-        // the partition's VP limit share VP 0 and are saved and restored around every slice.
-        private VirtualProcessor _vp;
+        // One VP per guest thread, so a thread switch moves no register state. A thread that cannot get one waits.
         private readonly List<VirtualProcessor> _processors = new();
+        private VirtualProcessor[] _processorSnapshot = Array.Empty<VirtualProcessor>();
         private readonly Stack<VirtualProcessor> _idleProcessors = new();
         private readonly Dictionary<uint, VirtualProcessor> _threadProcessors = new();
         private uint _processorLimit;
-        private int _runningVpIndex;
+
+        [ThreadStatic]
+        private static VirtualProcessor t_vp;
+        [ThreadStatic]
+        private static long t_vpBinding;
+
+        private VirtualProcessor CurrentVp
+        {
+            get
+            {
+                VirtualProcessor vp = t_vp;
+                return vp != null && ReferenceEquals(vp.Owner, this) && vp.Binding == t_vpBinding
+                    ? vp
+                    : _processors[(int)SharedVpIndex];
+            }
+        }
+
+        private static void SelectProcessor(VirtualProcessor vp)
+        {
+            t_vp = vp;
+            t_vpBinding = vp.Binding;
+        }
+
+        private object _runLock;
 
         private readonly WhvRegisterValue _userCodeSegment;
         private readonly WhvRegisterValue _userDataSegment;
@@ -117,28 +163,16 @@ namespace Brovan.Core.Emulation
         // The next slice clears the trap flag, so an armed completion cannot carry over.
         private const int CompletionGraceMilliseconds = 10;
 
-        private long _sliceDeadlineTimestamp;
-        private long _sliceGeneration;
-        private long _sliceExpiredGeneration;
-
-        private bool _completionActive;
-        private ulong _completionPageGpa;
-        private ulong _completionAccessGpa;
-        private uint _completionLen;
-        private bool _completionIsWrite;
-
         private int _disposed;
         private int _disposing;
-        private volatile bool _stopRequested;
-        private int _emulateThreadId;
-        private bool _singleStepRequested;
 
         public bool NoHooks;
         public static bool ThrowDisposed = true;
         public bool Disposed => Volatile.Read(ref _disposed) == 1;
         private bool Disposing => Volatile.Read(ref _disposing) == 1;
 
-        private WhpErrors _error;
+        [ThreadStatic]
+        private static WhpErrors _error;
 
         private sealed class MappedPage
         {
@@ -256,8 +290,8 @@ namespace Brovan.Core.Emulation
             InitializeGdt();
             InitializeSyscallTrapPage();
             InitializeExceptionHandling();
+            SelectProcessor(CreateProcessor(SharedVpIndex));
             RebuildMappings();
-            InitializeVirtualProcessorState(_vp);
         }
 
         public WhpErrors GetLastError() => _error;
@@ -571,7 +605,7 @@ namespace Brovan.Core.Emulation
                         RefreshMmioRegion(_mmioRegions[i]);
                 }
 
-                EnforceSliceDeadline();
+                EnforceSliceDeadlines();
 
                 Thread.Sleep(1);
             }
@@ -579,40 +613,52 @@ namespace Brovan.Core.Emulation
 
         public bool TryLimitSlice(int microseconds)
         {
+            VirtualProcessor vp = CurrentVp;
             long limit = Stopwatch.GetTimestamp() + (Stopwatch.Frequency * microseconds) / 1_000_000;
             while (true)
             {
-                long deadline = Volatile.Read(ref _sliceDeadlineTimestamp);
+                long deadline = Volatile.Read(ref vp.SliceDeadlineTimestamp);
                 if (deadline == 0)
                     return false;
                 if (limit >= deadline)
                     return true;
-                if (Interlocked.CompareExchange(ref _sliceDeadlineTimestamp, limit, deadline) == deadline)
+                if (Interlocked.CompareExchange(ref vp.SliceDeadlineTimestamp, limit, deadline) == deadline)
                     return true;
             }
         }
 
-        private void EnforceSliceDeadline()
+        private void EnforceSliceDeadlines()
         {
-            // Emulate arms the generation first, so reading it second keeps the pair consistent.
-            long deadline = Volatile.Read(ref _sliceDeadlineTimestamp);
-            long generation = Volatile.Read(ref _sliceGeneration);
-            if (deadline == 0 || Stopwatch.GetTimestamp() < deadline)
-                return;
-
             if (Disposed || Disposing)
                 return;
 
-            if (Interlocked.CompareExchange(ref _sliceDeadlineTimestamp, 0, deadline) != deadline)
-                return;
+            VirtualProcessor[] processors = Volatile.Read(ref _processorSnapshot);
+            long now = Stopwatch.GetTimestamp();
+            for (int i = 0; i < processors.Length; i++)
+            {
+                VirtualProcessor vp = processors[i];
 
-            // Naming the slice that ran out keeps a late cancel from ending the one that replaced it.
-            Volatile.Write(ref _sliceExpiredGeneration, generation);
+                // Emulate arms the generation first, so reading it second keeps the pair consistent.
+                long deadline = Volatile.Read(ref vp.SliceDeadlineTimestamp);
+                long generation = Volatile.Read(ref vp.SliceGeneration);
+                if (deadline == 0 || now < deadline)
+                    continue;
 
+                if (Interlocked.CompareExchange(ref vp.SliceDeadlineTimestamp, 0, deadline) != deadline)
+                    continue;
+
+                // Naming the slice that ran out keeps a late cancel from ending the one that replaced it.
+                Volatile.Write(ref vp.SliceExpiredGeneration, generation);
+                CancelRun(vp);
+            }
+        }
+
+        private void CancelRun(VirtualProcessor vp)
+        {
             lock (_partitionLock)
             {
                 if (_partition != IntPtr.Zero)
-                    WhpNative.WHvCancelRunVirtualProcessor(_partition, (uint)Volatile.Read(ref _runningVpIndex), 0);
+                    WhpNative.WHvCancelRunVirtualProcessor(_partition, vp.Index, 0);
             }
         }
 
@@ -924,7 +970,7 @@ namespace Brovan.Core.Emulation
 
             ref ulong target = ref GetGpRegisterPointer(ref GetRegistersRef(), access.Name);
             target = WriteGpRegisterField(target, access, value);
-            _vp.RegsDirty = true;
+            CurrentVp.RegsDirty = true;
             _error = WhpErrors.Ok;
             return true;
         }
@@ -940,7 +986,7 @@ namespace Brovan.Core.Emulation
 
             ref ulong target = ref GetGpRegisterPointer(ref GetRegistersRef(), access.Name);
             target = access.ZeroExtend32 ? value : WriteGpRegisterField(target, access, value);
-            _vp.RegsDirty = true;
+            CurrentVp.RegsDirty = true;
             _error = WhpErrors.Ok;
             return true;
         }
@@ -957,7 +1003,7 @@ namespace Brovan.Core.Emulation
             ref ulong target = ref GetGpRegisterPointer(ref GetRegistersRef(), access.Name);
             int shift = access.Offset * 8;
             target = (target & ~(0xFFUL << shift)) | ((ulong)value << shift);
-            _vp.RegsDirty = true;
+            CurrentVp.RegsDirty = true;
             _error = WhpErrors.Ok;
             return true;
         }
@@ -1015,32 +1061,34 @@ namespace Brovan.Core.Emulation
 
             if (_mappingsDirty) RebuildMappings();
 
-            ClearTrapFlag();
+            VirtualProcessor vp = CurrentVp;
+            ClearTrapFlag(vp);
 
-            GetRegistersRef().Rip = start;
-            _vp.RegsDirty = true;
+            GetRegistersRef(vp).Rip = start;
+            vp.RegsDirty = true;
 
-            FlushRegisterCache();
-            _stopRequested = false;
-            _emulateThreadId = Environment.CurrentManagedThreadId;
-            Volatile.Write(ref _runningVpIndex, (int)_vp.Index);
-            _singleStepRequested = count == 1;
+            FlushRegisterCache(vp);
+            vp.StopRequested = false;
+            vp.HostThreadId = Environment.CurrentManagedThreadId;
+            vp.SingleStepRequested = count == 1;
 
-            long SliceGeneration = Interlocked.Increment(ref _sliceGeneration);
+            long SliceGeneration = Interlocked.Increment(ref vp.SliceGeneration);
 
             if (count != 0)
             {
                 EnsureMaintenanceThread();
-                Volatile.Write(ref _sliceDeadlineTimestamp,
+                Volatile.Write(ref vp.SliceDeadlineTimestamp,
                     Stopwatch.GetTimestamp() + (Stopwatch.Frequency * BoundedSliceMilliseconds) / 1000);
             }
 
-            if (_singleStepRequested)
+            if (vp.SingleStepRequested)
             {
-                GetRegistersRef().Rflags |= 0x100UL;
-                _vp.RegsDirty = true;
-                FlushRegisterCache();
+                GetRegistersRef(vp).Rflags |= 0x100UL;
+                vp.RegsDirty = true;
+                FlushRegisterCache(vp);
             }
+
+            bool releaseRunLock = _runLock != null && Monitor.IsEntered(_runLock);
 
             try
             {
@@ -1049,9 +1097,9 @@ namespace Brovan.Core.Emulation
 
                 while (true)
                 {
-                    if (_stopRequested || Volatile.Read(ref _sliceExpiredGeneration) == SliceGeneration)
+                    if (vp.StopRequested || Volatile.Read(ref vp.SliceExpiredGeneration) == SliceGeneration)
                     {
-                        if (!_completionActive)
+                        if (!vp.CompletionActive)
                         {
                             break;
                         }
@@ -1061,29 +1109,29 @@ namespace Brovan.Core.Emulation
                             CompletionGraceEnd = Now + (Stopwatch.Frequency * CompletionGraceMilliseconds) / 1000;
                         else if (Now >= CompletionGraceEnd)
                         {
-                            AbandonSteppedCompletion();
+                            AbandonSteppedCompletion(vp);
                             break;
                         }
                     }
 
                     RefreshMmioBackedRegions();
 
-                    FlushRegisterCache();
+                    FlushRegisterCache(vp);
 
-                    ref WhvRunVpExitContext exit = ref RunVirtualProcessor();
-                    InvalidateRegisterCache();
+                    ref WhvRunVpExitContext exit = ref RunVirtualProcessor(vp, releaseRunLock);
+                    InvalidateRegisterCache(vp);
 
                     switch (exit.ExitReason)
                     {
                         case WhvRunVpExitReason.X64Halt:
-                            if (HandleHltExit()) continue;
+                            if (HandleHltExit(vp)) continue;
                             return _error == WhpErrors.Ok;
                         case WhvRunVpExitReason.MemoryAccess:
-                            if (HandleMemoryAccess(ref exit)) continue;
+                            if (HandleMemoryAccess(vp, ref exit)) continue;
                             _error = WhpErrors.Ok;
                             return true;
                         case WhvRunVpExitReason.Canceled:
-                            if (Volatile.Read(ref _sliceExpiredGeneration) == SliceGeneration && !_completionActive)
+                            if (Volatile.Read(ref vp.SliceExpiredGeneration) == SliceGeneration && !vp.CompletionActive)
                             {
                                 _error = WhpErrors.Ok;
                                 return true;
@@ -1111,14 +1159,14 @@ namespace Brovan.Core.Emulation
             }
             finally
             {
-                Volatile.Write(ref _sliceDeadlineTimestamp, 0);
+                Volatile.Write(ref vp.SliceDeadlineTimestamp, 0);
 
-                if (_singleStepRequested)
+                if (vp.SingleStepRequested)
                 {
-                    _singleStepRequested = false;
-                    ClearTrapFlag();
+                    vp.SingleStepRequested = false;
+                    ClearTrapFlag(vp);
                 }
-                FlushRegisterCache();
+                FlushRegisterCache(vp);
             }
         }
 
@@ -1126,34 +1174,70 @@ namespace Brovan.Core.Emulation
         {
             if (DisposedCheck()) return false;
 
-            RequestStop();
+            RequestStop(CurrentVp);
 
             _error = WhpErrors.Ok;
             return true;
         }
 
-        // _error belongs to the thread running the slice, so a stop raised from elsewhere leaves it alone.
-        // A cancel is only for a run in progress on another thread. Issued from the emulation thread
-        // itself, between runs, WHP keeps it pending and the next run returns Canceled at once.
-        private void RequestStop()
+        public void UseRunLock(object runLock) => _runLock = runLock;
+
+        public void StopThread(uint threadId)
         {
-            _stopRequested = true;
-            if (Environment.CurrentManagedThreadId == _emulateThreadId)
-                return;
-            if (_partition != IntPtr.Zero)
-                WhpNative.WHvCancelRunVirtualProcessor(_partition, (uint)Volatile.Read(ref _runningVpIndex), 0);
+            if (Disposed || Disposing) return;
+            if (!_threadProcessors.TryGetValue(threadId, out VirtualProcessor vp)) return;
+
+            vp.StopRequested = true;
+            if (vp.Running)
+                CancelRun(vp);
         }
 
-        private unsafe ref WhvRunVpExitContext RunVirtualProcessor()
+        public void StopAllProcessors()
         {
-            int hr = WhpNative.WHvRunVirtualProcessor(_partition, _vp.Index, (void*)_exitContextPtr,
-                (uint)sizeof(WhvRunVpExitContext));
+            if (Disposed || Disposing) return;
+
+            VirtualProcessor[] processors = Volatile.Read(ref _processorSnapshot);
+            for (int i = 0; i < processors.Length; i++)
+            {
+                VirtualProcessor vp = processors[i];
+                vp.StopRequested = true;
+                if (vp.Running)
+                    CancelRun(vp);
+            }
+        }
+
+        // A cancel is only for a run in progress on another thread. Issued from the VP's own thread between
+        // runs, WHP keeps it pending and the next run returns Canceled at once.
+        private void RequestStop(VirtualProcessor vp)
+        {
+            vp.StopRequested = true;
+            if (Environment.CurrentManagedThreadId == vp.HostThreadId)
+                return;
+            CancelRun(vp);
+        }
+
+        private unsafe ref WhvRunVpExitContext RunVirtualProcessor(VirtualProcessor vp, bool releaseRunLock)
+        {
+            int hr;
+            vp.Running = true;
+            if (releaseRunLock) Monitor.Exit(_runLock);
+            try
+            {
+                hr = WhpNative.WHvRunVirtualProcessor(_partition, vp.Index, (void*)vp.ExitContextPtr,
+                    (uint)sizeof(WhvRunVpExitContext));
+            }
+            finally
+            {
+                if (releaseRunLock) Monitor.Enter(_runLock);
+                vp.Running = false;
+            }
+
             if (WhpNative.Failed(hr))
             {
                 _error = WhpErrors.InternalError;
                 throw new WhpException("WHvRunVirtualProcessor failed", hr);
             }
-            return ref Unsafe.AsRef<WhvRunVpExitContext>((void*)_exitContextPtr);
+            return ref Unsafe.AsRef<WhvRunVpExitContext>((void*)vp.ExitContextPtr);
         }
 
         private const BackendHookType FaultMemoryHookTypes =
@@ -1398,10 +1482,14 @@ namespace Brovan.Core.Emulation
                     }
                 }
 
-                if (_exitContextPtr != IntPtr.Zero)
+                for (int i = 0; i < _processors.Count; i++)
                 {
-                    Marshal.FreeHGlobal(_exitContextPtr);
-                    _exitContextPtr = IntPtr.Zero;
+                    VirtualProcessor vp = _processors[i];
+                    if (vp.ExitContextPtr != IntPtr.Zero)
+                    {
+                        Marshal.FreeHGlobal(vp.ExitContextPtr);
+                        vp.ExitContextPtr = IntPtr.Zero;
+                    }
                 }
 
                 foreach (KeyValuePair<IntPtr, BackingAllocation> kv in _backingAllocations)
@@ -1477,20 +1565,20 @@ namespace Brovan.Core.Emulation
         private WhvRegisterValue MakeSegment(ushort selector, bool isCode, bool isUser)
             => WhvRegisterValue.FromSegment(0, 0xFFFFFFFF, selector, SegmentAttributes(isCode, isUser));
 
-        private void QueueCsSs(WhvRegisterValue cs, WhvRegisterValue ss)
+        private static void QueueCsSs(VirtualProcessor vp, WhvRegisterValue cs, WhvRegisterValue ss)
         {
-            _vp.PendingCs = cs;
-            _vp.PendingSs = ss;
-            _vp.SegmentsDirty = true;
+            vp.PendingCs = cs;
+            vp.PendingSs = ss;
+            vp.SegmentsDirty = true;
         }
 
-        private void ClearTrapFlag()
+        private void ClearTrapFlag(VirtualProcessor vp)
         {
-            ref WhpRegisters regs = ref GetRegistersRef();
+            ref WhpRegisters regs = ref GetRegistersRef(vp);
             if ((regs.Rflags & 0x100UL) == 0) return;
             regs.Rflags &= ~0x100UL;
-            _vp.RegsDirty = true;
-            FlushRegisterCache();
+            vp.RegsDirty = true;
+            FlushRegisterCache(vp);
         }
 
         private bool TryAllocateBackingMemory(ulong size, out IntPtr pointer)
@@ -1601,9 +1689,6 @@ namespace Brovan.Core.Emulation
                     throw new WhpException("WHvSetupPartition failed", hr);
             }
 
-            _vp = CreateProcessor(SharedVpIndex);
-
-            _exitContextPtr = Marshal.AllocHGlobal(sizeof(WhvRunVpExitContext));
         }
 
         private unsafe bool TrySetupPartition(uint processorCount, out int hr)
@@ -1621,15 +1706,59 @@ namespace Brovan.Core.Emulation
             return true;
         }
 
-        private VirtualProcessor CreateProcessor(uint index)
+        private unsafe VirtualProcessor CreateProcessor(uint index)
         {
             int hr = WhpNative.WHvCreateVirtualProcessor(_partition, index, 0);
             if (WhpNative.Failed(hr))
                 throw new WhpException("WHvCreateVirtualProcessor failed", hr);
 
-            VirtualProcessor vp = new VirtualProcessor { Index = index };
+            VirtualProcessor vp = new VirtualProcessor
+            {
+                Owner = this,
+                Index = index,
+                ExitContextPtr = Marshal.AllocHGlobal(sizeof(WhvRunVpExitContext)),
+            };
+
+            try
+            {
+                AllocateProcessorTables(vp);
+                InitializeVirtualProcessorState(vp);
+            }
+            catch
+            {
+                Marshal.FreeHGlobal(vp.ExitContextPtr);
+                vp.ExitContextPtr = IntPtr.Zero;
+                WhpNative.WHvDeleteVirtualProcessor(_partition, index);
+                throw;
+            }
+
             _processors.Add(vp);
+            Volatile.Write(ref _processorSnapshot, _processors.ToArray());
             return vp;
+        }
+
+        private unsafe void AllocateProcessorTables(VirtualProcessor vp)
+        {
+            vp.GdtPageGpa = AllocateInternalPage(false);
+            vp.TssPageGpa = AllocateInternalPage(false);
+            ulong stackSize = ExceptionStackPages * WhpConstants.PageSize;
+            ulong stackTop = AllocateInternalRange(stackSize, WhpMemoryPermission.ReadWrite) + stackSize;
+
+            if (!_mappedPages.TryGetValue(_gdtPageGpa, out MappedPage template)
+                || !_mappedPages.TryGetValue(vp.GdtPageGpa, out MappedPage gdtPage)
+                || !_mappedPages.TryGetValue(vp.TssPageGpa, out MappedPage tssPage))
+                throw new WhpException("Failed to allocate the processor tables.");
+
+            byte* gdt = (byte*)gdtPage.HostPage;
+            Unsafe.CopyBlockUnaligned(gdt, (byte*)template.HostPage, (uint)WhpConstants.PageSize);
+            int tssIndex = WhpConstants.TssSelector >> 3;
+            WriteDescriptor(gdt, tssIndex, vp.TssPageGpa & 0xFFFFFFFF, 0x67, 0x89, 0x0);
+            Unsafe.WriteUnaligned(gdt + (tssIndex + 1) * 8, vp.TssPageGpa >> 32);
+
+            byte* tss = (byte*)tssPage.HostPage;
+            Unsafe.WriteUnaligned(tss + 0x04, stackTop);
+            Unsafe.WriteUnaligned(tss + 0x24, stackTop);
+            Unsafe.WriteUnaligned(tss + 0x66, (ushort)0x68);
         }
 
         private static void ResetProcessorCache(VirtualProcessor vp)
@@ -1644,6 +1773,8 @@ namespace Brovan.Core.Emulation
         }
 
         public bool SupportsThreadResidency => _processorLimit > 1;
+
+        public int ProcessorLimit => (int)_processorLimit;
 
         public bool IsThreadResident(uint threadId) => _threadProcessors.ContainsKey(threadId);
 
@@ -1674,8 +1805,6 @@ namespace Brovan.Core.Emulation
                     _processorLimit = (uint)_processors.Count;
                     return false;
                 }
-
-                InitializeVirtualProcessorState(vp);
             }
 
             vp.ThreadId = threadId;
@@ -1690,14 +1819,13 @@ namespace Brovan.Core.Emulation
                 return;
 
             vp.ThreadId = 0;
+            vp.Binding++;
             _idleProcessors.Push(vp);
-            if (ReferenceEquals(_vp, vp))
-                _vp = _processors[(int)SharedVpIndex];
         }
 
         public void SelectThread(uint threadId)
         {
-            _vp = _threadProcessors.TryGetValue(threadId, out VirtualProcessor vp) ? vp : _processors[(int)SharedVpIndex];
+            SelectProcessor(_threadProcessors.TryGetValue(threadId, out VirtualProcessor vp) ? vp : _processors[(int)SharedVpIndex]);
         }
 
         private unsafe void InitializeVirtualProcessorState(VirtualProcessor vp)
@@ -1715,9 +1843,9 @@ namespace Brovan.Core.Emulation
             names[5] = (uint)WhvRegisterName.Gs;
             values[5] = _guest64 ? _userDataSegment : MakeSegment(WhpConstants.UserGsSelector32, false, true);
             names[6] = (uint)WhvRegisterName.Tr;
-            values[6] = WhvRegisterValue.FromSegment(_exceptionTssPageGpa, 0x67, WhpConstants.TssSelector, 0x8B);
+            values[6] = WhvRegisterValue.FromSegment(vp.TssPageGpa, 0x67, WhpConstants.TssSelector, 0x8B);
             names[7] = (uint)WhvRegisterName.Gdtr;
-            values[7] = WhvRegisterValue.FromTable(_gdtPageGpa, WhpConstants.GdtLimit);
+            values[7] = WhvRegisterValue.FromTable(vp.GdtPageGpa, WhpConstants.GdtLimit);
             names[8] = (uint)WhvRegisterName.Idtr;
             values[8] = WhvRegisterValue.FromTable(_exceptionIdtPageGpa, (ushort)(WhpConstants.ExceptionVectorCount * 16 - 1));
             names[9] = (uint)WhvRegisterName.Cr0; values[9] = WhvRegisterValue.FromReg64(0x80000033UL);
@@ -1806,10 +1934,6 @@ namespace Brovan.Core.Emulation
         {
             _exceptionStubPageGpa = AllocateInternalPage(true);
             _exceptionIdtPageGpa = AllocateInternalPage(false);
-            _exceptionTssPageGpa = AllocateInternalPage(false);
-
-            ulong exceptionStackSize = 16 * WhpConstants.PageSize;
-            _exceptionStackPageGpa = AllocateInternalRange(exceptionStackSize, WhpMemoryPermission.ReadWrite);
 
             unsafe
             {
@@ -1825,28 +1949,6 @@ namespace Brovan.Core.Emulation
                     byte* idt = (byte*)idtPage.HostPage;
                     for (uint vector = 0; vector < WhpConstants.ExceptionVectorCount; vector++)
                         WriteIdtGate(idt, vector, _exceptionStubPageGpa + vector * WhpConstants.ExceptionStubStride);
-                }
-
-                if (_mappedPages.TryGetValue(_exceptionTssPageGpa, out MappedPage tssPage))
-                {
-                    byte* tss = (byte*)tssPage.HostPage;
-                    ulong stackTop = _exceptionStackPageGpa + exceptionStackSize;
-                    Unsafe.WriteUnaligned(tss + 0x04, stackTop);
-                    Unsafe.WriteUnaligned(tss + 0x24, stackTop);
-                    ushort ioMapBase = 0x68;
-                    Unsafe.WriteUnaligned(tss + 0x66, ioMapBase);
-                }
-            }
-
-            if (_gdtPageGpa != 0 && _mappedPages.TryGetValue(_gdtPageGpa, out MappedPage gdtMapped) && gdtMapped.HostPage != IntPtr.Zero)
-            {
-                unsafe
-                {
-                    byte* gdt = (byte*)gdtMapped.HostPage;
-                    ulong tssBase = _exceptionTssPageGpa;
-                    int tssIndex = WhpConstants.TssSelector >> 3;
-                    WriteDescriptor(gdt, tssIndex, tssBase & 0xFFFFFFFF, 0x67, 0x89, 0x0);
-                    Unsafe.WriteUnaligned(gdt + (tssIndex + 1) * 8, tssBase >> 32);
                 }
             }
         }
@@ -2081,10 +2183,18 @@ namespace Brovan.Core.Emulation
             bool anyTrapped = _trappedPages.Count != 0;
 
             _desiredMaps.Clear();
+            MarkIntactMaps(0, ulong.MaxValue);
+            bool anyKept = _keptMapStarts.Count != 0;
 
             for (int i = 0; i < keyCount;)
             {
                 ulong runAddress = sortedKeys[i];
+                if (TryGetKeptMapEnd(runAddress, out ulong keptEnd))
+                {
+                    while (i < keyCount && sortedKeys[i] < keptEnd) i++;
+                    continue;
+                }
+
                 if (!_mappedPages.TryGetValue(runAddress, out MappedPage page)
                     || page == null
                     || page.HostPage == IntPtr.Zero
@@ -2117,6 +2227,7 @@ namespace Brovan.Core.Emulation
                 while (j < keyCount)
                 {
                     if (sortedKeys[j] != runAddress + runSize) break;
+                    if (anyKept && _keptMapStarts.Contains(sortedKeys[j])) break;
                     if (!_mappedPages.TryGetValue(sortedKeys[j], out MappedPage next) || next == null) break;
                     if (next.Permissions != page.Permissions) break;
                     if (anyTrapped && _trappedPages.ContainsKey(sortedKeys[j])) break;
@@ -2174,6 +2285,82 @@ namespace Brovan.Core.Emulation
             return index > 0 ? index - 1 : 0;
         }
 
+        // A map whose pages still map as installed stays as it is. Replacing it unmaps it for a moment from
+        // processors that are using it. Maps merge only when they run out.
+        private void MarkIntactMaps(ulong spanStart, ulong spanEnd)
+        {
+            _keptMapStarts.Clear();
+            if (_activeMaps.Count + MapHeadroom >= MaxGpaRanges) return;
+
+            int firstIndex = FirstActiveMapIndexAtOrBefore(spanStart);
+            for (int i = firstIndex; i < _activeMapStarts.Count; i++)
+            {
+                ulong start = _activeMapStarts[i];
+                if (start >= spanEnd) break;
+
+                InstalledMap active = _activeMaps[start];
+                if (start + active.Size <= spanStart) continue;
+                if (!IsMapIntact(start, active)) continue;
+
+                _keptMapStarts.Add(start);
+                _desiredMaps[start] = active;
+            }
+        }
+
+        private bool IsMapIntact(ulong start, InstalledMap map)
+        {
+            bool anyTrapped = _trappedPages.Count != 0;
+            for (ulong off = 0; off < map.Size; off += WhpConstants.PageSize)
+            {
+                ulong address = start + off;
+                if (!_mappedPages.TryGetValue(address, out MappedPage page)
+                    || page == null
+                    || page.HostPage == IntPtr.Zero
+                    || page.Permissions == WhpMemoryPermission.None)
+                    return false;
+                if (page.HostPage.ToInt64() != map.Host.ToInt64() + (long)off) return false;
+
+                WhvMapGpaRangeFlags flags;
+                if (anyTrapped && _trappedPages.TryGetValue(address, out bool writeOnly))
+                {
+                    if (!writeOnly || map.Size != WhpConstants.PageSize) return false;
+                    flags = WhvMapGpaRangeFlags.Read | WhvMapGpaRangeFlags.Execute;
+                }
+                else
+                {
+                    flags = ToWhpMapFlags(page.Permissions);
+                }
+                if (flags != map.Flags) return false;
+            }
+            return true;
+        }
+
+        private bool TryGetKeptMapEnd(ulong address, out ulong end)
+        {
+            end = 0;
+            if (_keptMapStarts.Count == 0 || _activeMapStarts.Count == 0) return false;
+
+            ulong start = _activeMapStarts[FirstActiveMapIndexAtOrBefore(address)];
+            if (start > address || !_keptMapStarts.Contains(start)) return false;
+
+            InstalledMap map = _activeMaps[start];
+            if (address - start >= map.Size) return false;
+            end = start + map.Size;
+            return true;
+        }
+
+        // A fault raised while another processor was replacing the mapping is retried once it is back.
+        private bool IsAccessInstalled(ulong gpa, bool isWrite)
+        {
+            if (_activeMapStarts.Count == 0) return false;
+
+            ulong start = _activeMapStarts[FirstActiveMapIndexAtOrBefore(gpa)];
+            if (start > gpa || !_activeMaps.TryGetValue(start, out InstalledMap map) || gpa - start >= map.Size)
+                return false;
+
+            return !isWrite || (map.Flags & WhvMapGpaRangeFlags.Write) != 0;
+        }
+
         private void RebuildMappingsIncremental(ulong spanStart, ulong spanEnd)
         {
             int firstIndex = FirstActiveMapIndexAtOrBefore(spanStart);
@@ -2191,6 +2378,7 @@ namespace Brovan.Core.Emulation
             }
 
             _desiredMaps.Clear();
+            MarkIntactMaps(spanStart, spanEnd);
             BuildDesiredMapsForSpan(spanStart, spanEnd);
 
             _staleMapKeys.Clear();
@@ -2230,9 +2418,16 @@ namespace Brovan.Core.Emulation
         private void BuildDesiredMapsForSpan(ulong spanStart, ulong spanEnd)
         {
             bool anyTrapped = _trappedPages.Count != 0;
+            bool anyKept = _keptMapStarts.Count != 0;
 
             for (ulong address = spanStart; address < spanEnd;)
             {
+                if (TryGetKeptMapEnd(address, out ulong keptEnd))
+                {
+                    address = keptEnd;
+                    continue;
+                }
+
                 if (!_mappedPages.TryGetValue(address, out MappedPage page)
                     || page == null
                     || page.HostPage == IntPtr.Zero
@@ -2263,6 +2458,7 @@ namespace Brovan.Core.Emulation
 
                 while (address + runSize < spanEnd)
                 {
+                    if (anyKept && _keptMapStarts.Contains(address + runSize)) break;
                     if (!_mappedPages.TryGetValue(address + runSize, out MappedPage next) || next == null) break;
                     if (next.Permissions != page.Permissions) break;
                     if (next.HostPage == IntPtr.Zero) break;
@@ -2362,13 +2558,13 @@ namespace Brovan.Core.Emulation
             return consumed;
         }
 
-        private bool HandleHltExit()
+        private bool HandleHltExit(VirtualProcessor vp)
         {
-            ulong rip = ReadRegister(Registers.UC_X86_REG_RIP);
+            ulong rip = GetRegistersRef(vp).Rip;
 
             if (_guest64 && _syscallHook != null && rip == (_syscallTrapPageGpa + 1))
             {
-                if (HandleSyscallTrap()) return true;
+                if (HandleSyscallTrap(vp)) return true;
                 _error = WhpErrors.Ok;
                 return false;
             }
@@ -2379,22 +2575,23 @@ namespace Brovan.Core.Emulation
             {
                 uint vector = (uint)((rip - 1 - _exceptionStubPageGpa) / WhpConstants.ExceptionStubStride);
 
-                if (_completionActive && vector == 1)
+                if (vp.CompletionActive && vector == 1)
                 {
-                    CompleteSteppedAccess(rip);
+                    CompleteSteppedAccess(vp, rip);
                     return true;
                 }
 
-                if (_singleStepRequested && vector == 1)
+                if (vp.SingleStepRequested && vector == 1)
                 {
-                    _singleStepRequested = false;
-                    RestoreExceptionFrame(rip);
-                    ClearTrapFlag();
+                    vp.SingleStepRequested = false;
+                    ReadExceptionFrame(vp, rip, out _, out _);
+                    ClearTrapFlag(vp);
                     _error = WhpErrors.Ok;
                     return false;
                 }
 
-                if (HandleExceptionTrap(rip))
+                ReadExceptionFrame(vp, rip, out uint faultVector, out ulong errorCode);
+                if (HandleException(faultVector, (uint)errorCode))
                     return true;
                 _error = WhpErrors.Exception;
                 return false;
@@ -2404,10 +2601,8 @@ namespace Brovan.Core.Emulation
             return false;
         }
 
-        private bool HandleMemoryAccess(ref WhvRunVpExitContext exit)
+        private bool HandleMemoryAccess(VirtualProcessor vp, ref WhvRunVpExitContext exit)
         {
-            if (_completionActive) return false;
-
             ulong gpa = exit.MemGpa;
             uint info = exit.MemAccessInfo;
             WhvMemoryAccessType accessType = (WhvMemoryAccessType)(info & 0x3);
@@ -2418,11 +2613,27 @@ namespace Brovan.Core.Emulation
             ulong faultPage = gpa & ~WhpConstants.PageMask;
             bool mapped = TryLookupPage(faultPage, out _);
 
+            if (vp.CompletionActive)
+            {
+                // Another processor re-trapped the page mid-step, so the step is armed again. A fault
+                // elsewhere belongs to the stepped instruction itself and ends the step.
+                if (faultPage == vp.CompletionPageGpa)
+                {
+                    ArmSteppedCompletion(vp, faultPage);
+                    return true;
+                }
+
+                AbandonSteppedCompletion(vp);
+            }
+
             if (mapped && _trappedPages.ContainsKey(faultPage))
             {
-                BeginSteppedCompletion(faultPage, gpa, len, isWrite);
+                BeginSteppedCompletion(vp, faultPage, gpa, len, isWrite);
                 return true;
             }
+
+            if (mapped && IsAccessInstalled(gpa, isWrite))
+                return true;
 
             BackendHookType required = mapped ? BackendHookType.MemoryProtected : BackendHookType.MemoryUnmapped;
             BackendMemoryAccessType type = mapped
@@ -2444,7 +2655,20 @@ namespace Brovan.Core.Emulation
             return false;
         }
 
-        private unsafe void BeginSteppedCompletion(ulong pageGpa, ulong gpa, uint len, bool isWrite)
+        private void BeginSteppedCompletion(VirtualProcessor vp, ulong pageGpa, ulong gpa, uint len, bool isWrite)
+        {
+            if (!_mappedPages.TryGetValue(pageGpa, out MappedPage page) || page.HostPage == IntPtr.Zero)
+                return;
+
+            vp.CompletionActive = true;
+            vp.CompletionPageGpa = pageGpa;
+            vp.CompletionAccessGpa = gpa;
+            vp.CompletionLen = len;
+            vp.CompletionIsWrite = isWrite;
+            ArmSteppedCompletion(vp, pageGpa);
+        }
+
+        private void ArmSteppedCompletion(VirtualProcessor vp, ulong pageGpa)
         {
             if (!_mappedPages.TryGetValue(pageGpa, out MappedPage page) || page.HostPage == IntPtr.Zero)
                 return;
@@ -2453,27 +2677,21 @@ namespace Brovan.Core.Emulation
             MapGpaRange(pageGpa, WhpConstants.PageSize, page.HostPage,
                 WhvMapGpaRangeFlags.Read | WhvMapGpaRangeFlags.Write | WhvMapGpaRangeFlags.Execute);
 
-            _completionActive = true;
-            _completionPageGpa = pageGpa;
-            _completionAccessGpa = gpa;
-            _completionLen = len;
-            _completionIsWrite = isWrite;
-
-            ref WhpRegisters regs = ref GetRegistersRef();
+            ref WhpRegisters regs = ref GetRegistersRef(vp);
             regs.Rflags |= 0x100UL;
-            _vp.RegsDirty = true;
-            FlushRegisterCache();
+            vp.RegsDirty = true;
+            FlushRegisterCache(vp);
         }
 
-        private void CompleteSteppedAccess(ulong stubRip)
+        private void CompleteSteppedAccess(VirtualProcessor vp, ulong stubRip)
         {
-            RestoreExceptionFrame(stubRip);
+            ReadExceptionFrame(vp, stubRip, out _, out _);
 
-            ulong pageGpa = _completionPageGpa;
-            ulong gpa = _completionAccessGpa;
-            uint len = _completionLen;
-            bool isWrite = _completionIsWrite;
-            _completionActive = false;
+            ulong pageGpa = vp.CompletionPageGpa;
+            ulong gpa = vp.CompletionAccessGpa;
+            uint len = vp.CompletionLen;
+            bool isWrite = vp.CompletionIsWrite;
+            vp.CompletionActive = false;
 
             ulong value = ReadMemoryULong(gpa);
             BackendHookType required = isWrite ? BackendHookType.MemoryWrite : BackendHookType.MemoryRead;
@@ -2498,57 +2716,61 @@ namespace Brovan.Core.Emulation
 
             ReTrapPage(pageGpa);
 
-            if (!_singleStepRequested)
-                ClearTrapFlag();
-            FlushRegisterCache();
+            if (!vp.SingleStepRequested)
+                ClearTrapFlag(vp);
+            FlushRegisterCache(vp);
         }
 
         /// <summary>
         /// Gives up a stepped access whose #DB never arrived. The guest faults on the page again.
         /// </summary>
-        private void AbandonSteppedCompletion()
+        private void AbandonSteppedCompletion(VirtualProcessor vp)
         {
-            if (!_completionActive)
+            if (!vp.CompletionActive)
                 return;
 
-            ulong pageGpa = _completionPageGpa;
-            _completionActive = false;
-            _completionPageGpa = 0;
-            _completionAccessGpa = 0;
-            _completionLen = 0;
-            _completionIsWrite = false;
+            ulong pageGpa = vp.CompletionPageGpa;
+            vp.CompletionActive = false;
+            vp.CompletionPageGpa = 0;
+            vp.CompletionAccessGpa = 0;
+            vp.CompletionLen = 0;
+            vp.CompletionIsWrite = false;
 
             ReTrapPage(pageGpa);
-            ClearTrapFlag();
-            FlushRegisterCache();
+            ClearTrapFlag(vp);
+            FlushRegisterCache(vp);
         }
 
         private void ReTrapPage(ulong pageGpa)
         {
             UnmapGpaRange(pageGpa, WhpConstants.PageSize);
-            if (_trappedPages.TryGetValue(pageGpa, out bool writeOnly) && writeOnly
-                && _mappedPages.TryGetValue(pageGpa, out MappedPage page) && page.HostPage != IntPtr.Zero)
+
+            if (_activeMapStarts.Count != 0)
             {
-                MapGpaRange(pageGpa, WhpConstants.PageSize, page.HostPage,
-                    WhvMapGpaRangeFlags.Read | WhvMapGpaRangeFlags.Execute);
+                ulong start = _activeMapStarts[FirstActiveMapIndexAtOrBefore(pageGpa)];
+                if (start <= pageGpa && _activeMaps.TryGetValue(start, out InstalledMap map) && pageGpa - start < map.Size)
+                {
+                    MapGpaRange(pageGpa, WhpConstants.PageSize, new IntPtr(map.Host.ToInt64() + (long)(pageGpa - start)), map.Flags);
+                    return;
+                }
             }
+
+            if (!_mappedPages.TryGetValue(pageGpa, out MappedPage page) || page == null
+                || page.HostPage == IntPtr.Zero || page.Permissions == WhpMemoryPermission.None)
+                return;
+
+            WhvMapGpaRangeFlags flags = _trappedPages.TryGetValue(pageGpa, out bool writeOnly) && writeOnly
+                ? WhvMapGpaRangeFlags.Read | WhvMapGpaRangeFlags.Execute
+                : ToWhpMapFlags(page.Permissions);
+            MapGpaRange(pageGpa, WhpConstants.PageSize, page.HostPage, flags);
         }
 
-        private void RestoreExceptionFrame(ulong stubRip)
-            => ReadExceptionFrame(stubRip, out _, out _);
-
-        private bool HandleExceptionTrap(ulong stubRip)
-        {
-            ReadExceptionFrame(stubRip, out uint vector, out ulong errorCode);
-            return HandleException(vector, (uint)errorCode);
-        }
-
-        private void ReadExceptionFrame(ulong stubRip, out uint vector, out ulong errorCode)
+        private void ReadExceptionFrame(VirtualProcessor vp, ulong stubRip, out uint vector, out ulong errorCode)
         {
             vector = (uint)((stubRip - 1 - _exceptionStubPageGpa) / WhpConstants.ExceptionStubStride);
             errorCode = 0;
 
-            ref WhpRegisters regs = ref GetRegistersRef();
+            ref WhpRegisters regs = ref GetRegistersRef(vp);
             ulong frameAddress = regs.Rsp;
 
             if (ExceptionHasErrorCode(vector))
@@ -2574,17 +2796,17 @@ namespace Brovan.Core.Emulation
             if (vector == 3) regs.Rip -= 1;
             regs.Rsp = frameRsp;
             regs.Rflags = frameRflags;
-            _vp.RegsDirty = true;
+            vp.RegsDirty = true;
 
-            QueueCsSs(MakeSegment((ushort)frameCs, true, (frameCs & 3) == 3),
+            QueueCsSs(vp, MakeSegment((ushort)frameCs, true, (frameCs & 3) == 3),
                 MakeSegment((ushort)frameSs, false, (frameSs & 3) == 3));
         }
 
-        private bool HandleSyscallTrap()
+        private bool HandleSyscallTrap(VirtualProcessor vp)
         {
             if (_syscallHook == null) return false;
 
-            ref WhpRegisters regs = ref GetRegistersRef();
+            ref WhpRegisters regs = ref GetRegistersRef(vp);
 
             ulong postSyscallRcx = regs.Rcx;
             ulong postSyscallR10 = regs.R10;
@@ -2594,19 +2816,19 @@ namespace Brovan.Core.Emulation
             regs.Rip = preSyscallRip;
             regs.Rcx = postSyscallR10;
             regs.Rflags = savedRflags;
-            _vp.RegsDirty = true;
+            vp.RegsDirty = true;
 
             if (_syscallHook.Callback != null) _syscallHook.Callback();
             else if (_syscallHook.BoolCallback != null) _syscallHook.BoolCallback();
 
-            ref WhpRegisters after = ref GetRegistersRef();
+            ref WhpRegisters after = ref GetRegistersRef(vp);
             if (after.Rip == preSyscallRip)
                 after.Rip = postSyscallRcx;
             else
                 after.Rip += 2;
-            _vp.RegsDirty = true;
+            vp.RegsDirty = true;
 
-            QueueCsSs(_userCodeSegment, _userDataSegment);
+            QueueCsSs(vp, _userCodeSegment, _userDataSegment);
             return true;
         }
 
@@ -2651,18 +2873,21 @@ namespace Brovan.Core.Emulation
 
         private void AdvanceRip(ulong amount)
         {
-            GetRegistersRef().Rip += amount;
-            _vp.RegsDirty = true;
+            VirtualProcessor vp = CurrentVp;
+            GetRegistersRef(vp).Rip += amount;
+            vp.RegsDirty = true;
         }
 
-        private unsafe ref WhpRegisters GetRegistersRef()
+        private ref WhpRegisters GetRegistersRef() => ref GetRegistersRef(CurrentVp);
+
+        private ref WhpRegisters GetRegistersRef(VirtualProcessor vp)
         {
-            if (!_vp.RegsValid)
+            if (!vp.RegsValid)
             {
-                LoadRegisters();
-                _vp.RegsValid = true;
+                LoadRegisters(vp);
+                vp.RegsValid = true;
             }
-            return ref _vp.Regs;
+            return ref vp.Regs;
         }
 
         internal const int XmmRegisterCount = 16;
@@ -2702,71 +2927,72 @@ namespace Brovan.Core.Emulation
             if (Values == null || Values.Length < XmmRegisterCount * 2)
                 return false;
 
+            VirtualProcessor vp = CurrentVp;
             if (Write)
             {
                 // The cache also carries the two control registers, which this call does not supply.
-                if (!_vp.XmmValid && !LoadXmmRegisters())
+                if (!vp.XmmValid && !LoadXmmRegisters(vp))
                     return false;
 
                 for (int i = 0; i < XmmRegisterCount; i++)
                 {
-                    _vp.Xmm[i].Low = Values[i * 2];
-                    _vp.Xmm[i].High = Values[i * 2 + 1];
+                    vp.Xmm[i].Low = Values[i * 2];
+                    vp.Xmm[i].High = Values[i * 2 + 1];
                 }
 
-                _vp.XmmDirty = true;
+                vp.XmmDirty = true;
                 return true;
             }
 
-            if (!_vp.XmmValid && !LoadXmmRegisters())
+            if (!vp.XmmValid && !LoadXmmRegisters(vp))
                 return false;
 
             for (int i = 0; i < XmmRegisterCount; i++)
             {
-                Values[i * 2] = _vp.Xmm[i].Low;
-                Values[i * 2 + 1] = _vp.Xmm[i].High;
+                Values[i * 2] = vp.Xmm[i].Low;
+                Values[i * 2 + 1] = vp.Xmm[i].High;
             }
 
             return true;
         }
 
-        private unsafe bool LoadXmmRegisters()
+        private unsafe bool LoadXmmRegisters(VirtualProcessor vp)
         {
             lock (_vcpuLock)
             {
                 fixed (uint* Names = VectorRegNames)
-                fixed (WhvRegisterValue* Vals = _vp.Xmm)
+                fixed (WhvRegisterValue* Vals = vp.Xmm)
                 {
-                    int Hr = WhpNative.WHvGetVirtualProcessorRegisters(_partition, _vp.Index, Names, VectorRegisterCount, Vals);
+                    int Hr = WhpNative.WHvGetVirtualProcessorRegisters(_partition, vp.Index, Names, VectorRegisterCount, Vals);
                     if (WhpNative.Failed(Hr))
                         return false;
                 }
             }
 
-            _vp.XmmValid = true;
+            vp.XmmValid = true;
             return true;
         }
 
-        private unsafe void StoreXmmRegisters()
+        private unsafe void StoreXmmRegisters(VirtualProcessor vp)
         {
             lock (_vcpuLock)
             {
                 fixed (uint* Names = VectorRegNames)
-                fixed (WhvRegisterValue* Vals = _vp.Xmm)
+                fixed (WhvRegisterValue* Vals = vp.Xmm)
                 {
-                    int Hr = WhpNative.WHvSetVirtualProcessorRegisters(_partition, _vp.Index, Names, VectorRegisterCount, Vals);
+                    int Hr = WhpNative.WHvSetVirtualProcessorRegisters(_partition, vp.Index, Names, VectorRegisterCount, Vals);
                     if (WhpNative.Failed(Hr))
                         throw new WhpException("WHvSetVirtualProcessorRegisters(XMM) failed", Hr);
                 }
             }
 
-            _vp.XmmDirty = false;
+            vp.XmmDirty = false;
         }
 
         // XMM is deliberately not folded into this call. Reading XMM makes WHP extract the full FP
         // state, which costs far more than the call it would save: a GP load runs on every VM exit,
         // an XMM read only on a context switch. Merging the two here measured 1.7s -> 16.8s.
-        private unsafe void LoadRegisters()
+        private unsafe void LoadRegisters(VirtualProcessor vp)
         {
             Span<WhvRegisterValue> values = stackalloc WhvRegisterValue[GpRegNames.Length];
             lock (_vcpuLock)
@@ -2774,73 +3000,73 @@ namespace Brovan.Core.Emulation
                 fixed (uint* names = GpRegNames)
                 fixed (WhvRegisterValue* vals = values)
                 {
-                    int hr = WhpNative.WHvGetVirtualProcessorRegisters(_partition, _vp.Index, names,
+                    int hr = WhpNative.WHvGetVirtualProcessorRegisters(_partition, vp.Index, names,
                         (uint)GpRegNames.Length, vals);
                     if (WhpNative.Failed(hr))
                         throw new WhpException("WHvGetVirtualProcessorRegisters(GP) failed", hr);
                 }
             }
 
-            _vp.Regs.Rax = values[0].Low;
-            _vp.Regs.Rbx = values[1].Low;
-            _vp.Regs.Rcx = values[2].Low;
-            _vp.Regs.Rdx = values[3].Low;
-            _vp.Regs.Rsi = values[4].Low;
-            _vp.Regs.Rdi = values[5].Low;
-            _vp.Regs.Rsp = values[6].Low;
-            _vp.Regs.Rbp = values[7].Low;
-            _vp.Regs.R8 = values[8].Low;
-            _vp.Regs.R9 = values[9].Low;
-            _vp.Regs.R10 = values[10].Low;
-            _vp.Regs.R11 = values[11].Low;
-            _vp.Regs.R12 = values[12].Low;
-            _vp.Regs.R13 = values[13].Low;
-            _vp.Regs.R14 = values[14].Low;
-            _vp.Regs.R15 = values[15].Low;
-            _vp.Regs.Rip = values[16].Low;
-            _vp.Regs.Rflags = values[17].Low;
+            vp.Regs.Rax = values[0].Low;
+            vp.Regs.Rbx = values[1].Low;
+            vp.Regs.Rcx = values[2].Low;
+            vp.Regs.Rdx = values[3].Low;
+            vp.Regs.Rsi = values[4].Low;
+            vp.Regs.Rdi = values[5].Low;
+            vp.Regs.Rsp = values[6].Low;
+            vp.Regs.Rbp = values[7].Low;
+            vp.Regs.R8 = values[8].Low;
+            vp.Regs.R9 = values[9].Low;
+            vp.Regs.R10 = values[10].Low;
+            vp.Regs.R11 = values[11].Low;
+            vp.Regs.R12 = values[12].Low;
+            vp.Regs.R13 = values[13].Low;
+            vp.Regs.R14 = values[14].Low;
+            vp.Regs.R15 = values[15].Low;
+            vp.Regs.Rip = values[16].Low;
+            vp.Regs.Rflags = values[17].Low;
         }
 
-        private unsafe void StoreRegisters()
+        private unsafe void StoreRegisters(VirtualProcessor vp)
         {
-            bool withSegments = _vp.SegmentsDirty;
-            bool withXmm = _vp.XmmDirty;
+            bool withSegments = vp.SegmentsDirty;
+            bool withXmm = vp.XmmDirty;
             uint[] names = withSegments
                 ? (withXmm ? GpSegXmmRegNames : GpRegNamesWithSegments)
                 : (withXmm ? GpXmmRegNames : GpRegNames);
             Span<WhvRegisterValue> values = stackalloc WhvRegisterValue[GpSegXmmRegNames.Length];
-            values[0] = WhvRegisterValue.FromReg64(_vp.Regs.Rax);
-            values[1] = WhvRegisterValue.FromReg64(_vp.Regs.Rbx);
-            values[2] = WhvRegisterValue.FromReg64(_vp.Regs.Rcx);
-            values[3] = WhvRegisterValue.FromReg64(_vp.Regs.Rdx);
-            values[4] = WhvRegisterValue.FromReg64(_vp.Regs.Rsi);
-            values[5] = WhvRegisterValue.FromReg64(_vp.Regs.Rdi);
-            values[6] = WhvRegisterValue.FromReg64(_vp.Regs.Rsp);
-            values[7] = WhvRegisterValue.FromReg64(_vp.Regs.Rbp);
-            values[8] = WhvRegisterValue.FromReg64(_vp.Regs.R8);
-            values[9] = WhvRegisterValue.FromReg64(_vp.Regs.R9);
-            values[10] = WhvRegisterValue.FromReg64(_vp.Regs.R10);
-            values[11] = WhvRegisterValue.FromReg64(_vp.Regs.R11);
-            values[12] = WhvRegisterValue.FromReg64(_vp.Regs.R12);
-            values[13] = WhvRegisterValue.FromReg64(_vp.Regs.R13);
-            values[14] = WhvRegisterValue.FromReg64(_vp.Regs.R14);
-            values[15] = WhvRegisterValue.FromReg64(_vp.Regs.R15);
-            values[16] = WhvRegisterValue.FromReg64(_vp.Regs.Rip);
-            values[17] = WhvRegisterValue.FromReg64(_vp.Regs.Rflags | 0x2UL);
+            values[0] = WhvRegisterValue.FromReg64(vp.Regs.Rax);
+            values[1] = WhvRegisterValue.FromReg64(vp.Regs.Rbx);
+            values[2] = WhvRegisterValue.FromReg64(vp.Regs.Rcx);
+            values[3] = WhvRegisterValue.FromReg64(vp.Regs.Rdx);
+            values[4] = WhvRegisterValue.FromReg64(vp.Regs.Rsi);
+            values[5] = WhvRegisterValue.FromReg64(vp.Regs.Rdi);
+            values[6] = WhvRegisterValue.FromReg64(vp.Regs.Rsp);
+            values[7] = WhvRegisterValue.FromReg64(vp.Regs.Rbp);
+            values[8] = WhvRegisterValue.FromReg64(vp.Regs.R8);
+            values[9] = WhvRegisterValue.FromReg64(vp.Regs.R9);
+            values[10] = WhvRegisterValue.FromReg64(vp.Regs.R10);
+            values[11] = WhvRegisterValue.FromReg64(vp.Regs.R11);
+            values[12] = WhvRegisterValue.FromReg64(vp.Regs.R12);
+            values[13] = WhvRegisterValue.FromReg64(vp.Regs.R13);
+            values[14] = WhvRegisterValue.FromReg64(vp.Regs.R14);
+            values[15] = WhvRegisterValue.FromReg64(vp.Regs.R15);
+            values[16] = WhvRegisterValue.FromReg64(vp.Regs.Rip);
+            values[17] = WhvRegisterValue.FromReg64(vp.Regs.Rflags | 0x2UL);
 
             if (withSegments)
             {
-                values[18] = _vp.PendingCs;
-                values[19] = _vp.PendingSs;
-                _vp.SegmentsDirty = false;
+                values[18] = vp.PendingCs;
+                values[19] = vp.PendingSs;
+                vp.SegmentsDirty = false;
             }
 
             if (withXmm)
             {
                 int xmmBase = withSegments ? GpRegNamesWithSegments.Length : GpRegNames.Length;
                 for (int i = 0; i < VectorRegisterCount; i++)
-                    values[xmmBase + i] = _vp.Xmm[i];
-                _vp.XmmDirty = false;
+                    values[xmmBase + i] = vp.Xmm[i];
+                vp.XmmDirty = false;
             }
 
             lock (_vcpuLock)
@@ -2848,7 +3074,7 @@ namespace Brovan.Core.Emulation
                 fixed (uint* n = names)
                 fixed (WhvRegisterValue* vals = values)
                 {
-                    int hr = WhpNative.WHvSetVirtualProcessorRegisters(_partition, _vp.Index, n,
+                    int hr = WhpNative.WHvSetVirtualProcessorRegisters(_partition, vp.Index, n,
                         (uint)names.Length, vals);
                     if (WhpNative.Failed(hr))
                         throw new WhpException("WHvSetVirtualProcessorRegisters(GP) failed", hr);
@@ -2856,25 +3082,25 @@ namespace Brovan.Core.Emulation
             }
         }
 
-        private void FlushRegisterCache()
+        private void FlushRegisterCache(VirtualProcessor vp)
         {
-            if (_vp.RegsDirty || _vp.SegmentsDirty)
+            if (vp.RegsDirty || vp.SegmentsDirty)
             {
-                _vp.RegsDirty = false;
-                StoreRegisters();
+                vp.RegsDirty = false;
+                StoreRegisters(vp);
                 return;
             }
 
-            // _vp.Regs is only known-live once something has dirtied it, so a lone XMM write
-            // must not ride along a GP store that would push a stale cache into the processor.
-            if (_vp.XmmDirty)
-                StoreXmmRegisters();
+            // vp.Regs is only known live once something has dirtied it, so a lone XMM write must not ride
+            // along a GP store that would push a stale cache into the processor.
+            if (vp.XmmDirty)
+                StoreXmmRegisters(vp);
         }
 
-        private void InvalidateRegisterCache()
+        private static void InvalidateRegisterCache(VirtualProcessor vp)
         {
-            _vp.RegsValid = false;
-            _vp.XmmValid = false;
+            vp.RegsValid = false;
+            vp.XmmValid = false;
         }
 
         private unsafe void SetSingleRegister(WhvRegisterName name, WhvRegisterValue value)
@@ -2882,7 +3108,7 @@ namespace Brovan.Core.Emulation
             uint n = (uint)name;
             lock (_vcpuLock)
             {
-                int hr = WhpNative.WHvSetVirtualProcessorRegisters(_partition, _vp.Index, &n, 1, &value);
+                int hr = WhpNative.WHvSetVirtualProcessorRegisters(_partition, CurrentVp.Index, &n, 1, &value);
                 if (WhpNative.Failed(hr))
                     throw new WhpException($"WHvSetVirtualProcessorRegisters({name}) failed", hr);
             }
@@ -2890,14 +3116,15 @@ namespace Brovan.Core.Emulation
 
         private unsafe WhvRegisterValue GetSingleRegister(WhvRegisterName name)
         {
-            if (_vp.SegmentsDirty && (name == WhvRegisterName.Cs || name == WhvRegisterName.Ss))
-                FlushRegisterCache();
+            VirtualProcessor vp = CurrentVp;
+            if (vp.SegmentsDirty && (name == WhvRegisterName.Cs || name == WhvRegisterName.Ss))
+                FlushRegisterCache(vp);
 
             uint n = (uint)name;
             WhvRegisterValue value;
             lock (_vcpuLock)
             {
-                int hr = WhpNative.WHvGetVirtualProcessorRegisters(_partition, _vp.Index, &n, 1, &value);
+                int hr = WhpNative.WHvGetVirtualProcessorRegisters(_partition, vp.Index, &n, 1, &value);
                 if (WhpNative.Failed(hr))
                     throw new WhpException($"WHvGetVirtualProcessorRegisters({name}) failed", hr);
             }
@@ -2970,8 +3197,8 @@ namespace Brovan.Core.Emulation
 
             switch (register)
             {
-                case Registers.UC_X86_REG_FS_BASE: value = _vp.FsBase != ulong.MaxValue ? _vp.FsBase : GetSingleRegister(WhvRegisterName.Fs).Low; return true;
-                case Registers.UC_X86_REG_GS_BASE: value = _vp.GsBase != ulong.MaxValue ? _vp.GsBase : GetSingleRegister(WhvRegisterName.Gs).Low; return true;
+                case Registers.UC_X86_REG_FS_BASE: value = CurrentVp.FsBase != ulong.MaxValue ? CurrentVp.FsBase : GetSingleRegister(WhvRegisterName.Fs).Low; return true;
+                case Registers.UC_X86_REG_GS_BASE: value = CurrentVp.GsBase != ulong.MaxValue ? CurrentVp.GsBase : GetSingleRegister(WhvRegisterName.Gs).Low; return true;
                 case Registers.UC_X86_REG_CS: value = SegmentSelector(WhvRegisterName.Cs); return true;
                 case Registers.UC_X86_REG_SS: value = SegmentSelector(WhvRegisterName.Ss); return true;
                 case Registers.UC_X86_REG_DS: value = SegmentSelector(WhvRegisterName.Ds); return true;
@@ -2994,27 +3221,29 @@ namespace Brovan.Core.Emulation
         // LastFpRdp/XmmStatusControlMask), so a write is a read-modify-write of the cached value.
         private bool WriteFpControl(Registers register, ulong value)
         {
-            if (!_vp.XmmValid && !LoadXmmRegisters())
+            VirtualProcessor vp = CurrentVp;
+            if (!vp.XmmValid && !LoadXmmRegisters(vp))
                 return false;
 
             if (register == Registers.UC_X86_REG_FPCW)
-                _vp.Xmm[FpControlSlot].Low = (_vp.Xmm[FpControlSlot].Low & ~0xFFFFUL) | (ushort)value;
+                vp.Xmm[FpControlSlot].Low = (vp.Xmm[FpControlSlot].Low & ~0xFFFFUL) | (ushort)value;
             else
-                _vp.Xmm[XmmControlSlot].High = (_vp.Xmm[XmmControlSlot].High & ~0xFFFFFFFFUL) | (uint)value;
+                vp.Xmm[XmmControlSlot].High = (vp.Xmm[XmmControlSlot].High & ~0xFFFFFFFFUL) | (uint)value;
 
-            _vp.XmmDirty = true;
+            vp.XmmDirty = true;
             return true;
         }
 
         private bool ReadFpControl(Registers register, out ulong value)
         {
             value = 0;
-            if (!_vp.XmmValid && !LoadXmmRegisters())
+            VirtualProcessor vp = CurrentVp;
+            if (!vp.XmmValid && !LoadXmmRegisters(vp))
                 return false;
 
             value = register == Registers.UC_X86_REG_FPCW
-                ? (ushort)_vp.Xmm[FpControlSlot].Low
-                : (uint)_vp.Xmm[XmmControlSlot].High;
+                ? (ushort)vp.Xmm[FpControlSlot].Low
+                : (uint)vp.Xmm[XmmControlSlot].High;
             return true;
         }
 
@@ -3029,7 +3258,8 @@ namespace Brovan.Core.Emulation
 
         private void WriteSegmentBase(WhvRegisterName name, ulong baseAddress)
         {
-            ref ulong cached = ref (name == WhvRegisterName.Gs ? ref _vp.GsBase : ref _vp.FsBase);
+            VirtualProcessor vp = CurrentVp;
+            ref ulong cached = ref (name == WhvRegisterName.Gs ? ref vp.GsBase : ref vp.FsBase);
             if (_guest64 && cached == baseAddress)
                 return;
 
@@ -3046,7 +3276,7 @@ namespace Brovan.Core.Emulation
         {
             int index = selector >> 3;
             if (index != WhpConstants.UserFsSelector32 >> 3) return;
-            if (!_mappedPages.TryGetValue(_gdtPageGpa, out MappedPage gdtPage) || gdtPage.HostPage == IntPtr.Zero) return;
+            if (!_mappedPages.TryGetValue(CurrentVp.GdtPageGpa, out MappedPage gdtPage) || gdtPage.HostPage == IntPtr.Zero) return;
 
             byte* descriptor = (byte*)gdtPage.HostPage + index * 8;
             descriptor[2] = (byte)segmentBase;

--- a/Brovan/Core/Emulation/WhpBinding/Whp.cs
+++ b/Brovan/Core/Emulation/WhpBinding/Whp.cs
@@ -1818,6 +1818,10 @@ namespace Brovan.Core.Emulation
             if (!_threadProcessors.Remove(threadId, out VirtualProcessor vp))
                 return;
 
+            // A completion the next thread on this processor would finish against the wrong page.
+            AbandonSteppedCompletion(vp);
+            vp.StopRequested = false;
+            vp.SingleStepRequested = false;
             vp.ThreadId = 0;
             vp.Binding++;
             _idleProcessors.Push(vp);

--- a/Brovan/EmulationMenu/EmulationMenu.cs
+++ b/Brovan/EmulationMenu/EmulationMenu.cs
@@ -2348,7 +2348,7 @@ namespace Brovan.EmulationMenu
             }
         }
 
-        public static void RunEmulator(string FilePath, bool Quick, bool Silent, [AllowNull] string Command, [AllowNull] string RawProgramArguments, string[] ProgramArguments, NetworkAccessPolicy NetworkPolicyValue, bool NoHooks, EmulationBackendKind BackendKind, [AllowNull] string WorkingDirectory = null)
+        public static void RunEmulator(string FilePath, bool Quick, bool Silent, [AllowNull] string Command, [AllowNull] string RawProgramArguments, string[] ProgramArguments, NetworkAccessPolicy NetworkPolicyValue, bool NoHooks, EmulationBackendKind BackendKind, [AllowNull] string WorkingDirectory = null, bool Smp = true, int SmpWorkers = 0)
         {
             SilentMode = Silent;
 
@@ -2417,6 +2417,8 @@ namespace Brovan.EmulationMenu
                     ProgramArguments = ProgramArguments ?? Array.Empty<string>(),
                     NoHooks = NoHooks,
                     BackendKind = BackendKind,
+                    Smp = Smp,
+                    SmpWorkers = SmpWorkers,
                     StartSuspended = GuestProcessLauncher.StartedSuspended()
                 };
 

--- a/Brovan/Program.cs
+++ b/Brovan/Program.cs
@@ -97,7 +97,7 @@ namespace Brovan
             {
                 string Arg = args[i];
 
-                if (Arg == "-c" || Arg == "--command" || Arg == "--net" || Arg == "--net-allow")
+                if (Arg == "-c" || Arg == "--command" || Arg == "--net" || Arg == "--net-allow" || Arg == "--cores")
                 {
                     i++;
                     continue;
@@ -129,6 +129,8 @@ namespace Brovan
             Console.WriteLine("  --net-allow=<ip>  Allow a specific IPv4 or IPv6 address in addition to the selected policy.");
             Console.WriteLine("  --no-hooks        Run the emulator with no hooks. useful when you want maximum performance and want to see some program output.");
             Console.WriteLine("  --backend=<name>  Choose the emulation backend: unicorn (default), kvm (Linux), or whp (Windows Hypervisor Platform).");
+            Console.WriteLine("  --cores=<n>       Guest threads a hypervisor backend runs at once. Defaults to the host's logical processors minus one.");
+            Console.WriteLine("  --no-smp          Run guest threads one at a time on a hypervisor backend, through the cooperative scheduler.");
             Console.WriteLine("  --cwd <dir>       Directory the emulated program starts in. Defaults to the directory of the binary.");
             Console.WriteLine("  --jit-cache[=<dir>]");
             Console.WriteLine("                    Directory for the persisted Unicorn JIT code cache, which lets a");
@@ -517,6 +519,8 @@ namespace Brovan
 
             bool Quick = true;
             bool NoHooks = false;
+            bool Smp = true;
+            int SmpWorkers = 0;
             bool Silent = false;
             string Command = null;
             string FilePath = null;
@@ -581,6 +585,18 @@ namespace Brovan
                         continue;
                     case "--no-hooks":
                         NoHooks = true;
+                        continue;
+                    case "--no-smp":
+                        Smp = false;
+                        continue;
+                    case "--cores":
+                        if (i + 1 >= args.Length || !int.TryParse(args[i + 1], out SmpWorkers) || SmpWorkers < 1)
+                        {
+                            PrintHighlight("[-] Invalid core count. expected a positive number.", true);
+                            return;
+                        }
+
+                        i++;
                         continue;
                     case "--no-jit-cache":
                         UnicornCodeCache.Enabled = false;
@@ -675,6 +691,17 @@ namespace Brovan
                     continue;
                 }
 
+                if (Arg.StartsWith("--cores=", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!int.TryParse(Arg.Substring("--cores=".Length), out SmpWorkers) || SmpWorkers < 1)
+                    {
+                        PrintHighlight("[-] Invalid core count. expected a positive number.", true);
+                        return;
+                    }
+
+                    continue;
+                }
+
                 if (Arg.StartsWith("--jit-cache=", StringComparison.OrdinalIgnoreCase))
                 {
                     UnicornCodeCache.Enabled = true;
@@ -707,7 +734,7 @@ namespace Brovan
 
             // Set the dll import resolver based on the platform
             NativeLibraryResolver.Register();
-            EmulationMenu.EmulationMenu.RunEmulator(FilePath, Quick, Silent, Command, RawProgramArguments, ProgramArguments, NetworkPolicy, NoHooks, BackendKind, WorkingDirectory);
+            EmulationMenu.EmulationMenu.RunEmulator(FilePath, Quick, Silent, Command, RawProgramArguments, ProgramArguments, NetworkPolicy, NoHooks, BackendKind, WorkingDirectory, Smp, SmpWorkers);
         }
     }
 }


### PR DESCRIPTION
Guest threads now run on several host threads at once on a hypervisor backend. A kernel lock covers every host thread that touches emulator, OS layer or backend state, and the backend releases it only for the time a processor spends in the guest. Scheduler state that used to sit on the emulator moved to a per host thread worker, so each worker holds its own current thread, context flag and register scratch. A dispatched thread is hidden from every scan and given back on every route out of a slice. Idle workers wait on the kernel lock and a sweep thread pulses one at the idle cadence, because a timed wake has no producer. `--no-smp` runs the single thread scheduler unchanged and `--cores=<n>` sets how many threads run together, both forwarded to a guest process the emulator launches.

The backend interface gains ProcessorLimit, UseRunLock, StopThread and StopAllProcessors. The WHP and KVM bindings give each guest thread its own virtual processor, so a thread switch moves no register state, and a thread that cannot get one waits. Per processor state moved out of the binding and into the processor object, including the register cache, the stepped completion, the stop request and the GDT, TSS and interrupt stack. A slice deadline is named by generation so a late cancel cannot end the slice that replaced it. A rebuild keeps a mapping whose pages still map as installed instead of replacing it, because a processor delivering an exception through the gap cannot recover. KVM offsets the counter of a later virtual processor onto the first one, and RDTSC is answered from the real counter when the backend has one.

NtGetContextThread, NtSetContextThread and NtTerminateThread park the target thread before they read or change it, and the context calls answer STATUS_UNSUCCESSFUL when it never reaches a safe point. NtSuspendThread and NtQueueApcThread end the target's slice instead of the calling one. A thread that has ended releases its TEB, its initial stack and its initial context, and its thread object stays only while a handle refers to it. NtLockFile retries a conflicting lock through a slice rather than sleeping on the host thread.

The 64 bit fields of KUSER_SHARED_DATA are written with the high half first, so a reader that retries while High1Time differs from High2Time reads a whole value, and the hypervisor shared page stores its offset before the sequence that publishes it. The module list poll reads the PEB_LDR_DATA list head instead of watching writes to the page it shares with the loader lock.

On Linux the syscall helper takes the current thread id from the emulator and keeps CpuidEnabled on the thread rather than on the helper.